### PR TITLE
Fix leaf creation refunding stake

### DIFF
--- a/protocol/assertions.go
+++ b/protocol/assertions.go
@@ -201,7 +201,7 @@ func (chain *AssertionChain) CreateLeaf(prev *Assertion, commitment StateCommitm
 				if err := chain.DeductFromBalance(staker, AssertionStakeWei); err != nil {
 					return err
 				}
-				chain.AddToBalance(staker, AssertionStakeWei)
+				chain.AddToBalance(oldStaker, AssertionStakeWei)
 				prev.staker = util.EmptyOption[common.Address]()
 			}
 			return nil

--- a/protocol/assertions_test.go
+++ b/protocol/assertions_test.go
@@ -109,6 +109,25 @@ func TestAssertionChain(t *testing.T) {
 	}
 }
 
+func TestAssertionChain_LeafCreationThroughDiffStakers(t *testing.T) {
+	ctx := context.Background()
+	chain := NewAssertionChain(ctx, util.NewArtificialTimeReference(), testChallengePeriod)
+
+	oldStaker := common.BytesToAddress([]byte{1})
+	staker := common.BytesToAddress([]byte{2})
+	require.Equal(t, chain.GetBalance(oldStaker), big.NewInt(0)) // Old staker has 0 because it's already staked.
+	chain.SetBalance(staker, AssertionStakeWei)
+	require.Equal(t, chain.GetBalance(staker), AssertionStakeWei) // New staker has full balance because it's not yet staked.
+
+	lc := chain.LatestConfirmed()
+	lc.staker = util.FullOption[common.Address](oldStaker)
+	_, err := chain.CreateLeaf(lc, StateCommitment{Height: 1, StateRoot: common.Hash{}}, staker)
+	require.NoError(t, err)
+
+	require.Equal(t, chain.GetBalance(staker), big.NewInt(0))        // New staker has 0 balance after staking.
+	require.Equal(t, chain.GetBalance(oldStaker), AssertionStakeWei) // Old staker has full balance after unstaking.
+}
+
 func verifyCreateLeafEventInFeed(t *testing.T, c <-chan AssertionChainEvent, seqNum, prevSeqNum uint64, staker common.Address, comm StateCommitment) {
 	t.Helper()
 	ev := <-c

--- a/util/option_type.go
+++ b/util/option_type.go
@@ -54,6 +54,7 @@ func (o Option[T]) IfLet(fullFunc func(T) error, emptyFunc func() error) error {
 	} else {
 		fullFunc(*o.value)
 	}
+	return nil
 }
 
 type Result[T any] struct {


### PR DESCRIPTION
For leaf creation, if the new staker is different than the old staker, then the old staker should be receiving its balance back (not the new staker)