### PR TITLE
Fix option type's `IfLet` method to properly return errors

### DIFF
--- a/util/option_type.go
+++ b/util/option_type.go
@@ -49,10 +49,10 @@ func OptionMapOrElse[T, U any](o Option[T], f func(T) U, valueIfEmpty U) U {
 func (o Option[T]) IfLet(fullFunc func(T) error, emptyFunc func() error) error {
 	if o.value == nil {
 		if emptyFunc != nil {
-			emptyFunc()
+			return emptyFunc()
 		}
 	} else {
-		fullFunc(*o.value)
+		return fullFunc(*o.value)
 	}
 	return nil
 }


### PR DESCRIPTION
option type's `IfLet` method missed returning errors, therefore staker's balance falls below `AssertionStakeWei` and goes undetected.  We added the returns and unit tests 