### PR TITLE
Updated process new leaf method with questions

### DIFF
--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -47,7 +47,7 @@ func Test_processLeafCreation(t *testing.T) {
 		}
 		err := v.processLeafCreation(ctx, ev)
 		require.NoError(t, err)
-		AssertLogsContain(t, logsHook, "New leaf appended")
+		AssertLogsContain(t, logsHook, "Processing new leaf from the protocol")
 		AssertLogsContain(t, logsHook, "No fork detected in assertion tree")
 	})
 	t.Run("fork leads validator to defend leaf", func(t *testing.T) {
@@ -104,7 +104,7 @@ func Test_processLeafCreation(t *testing.T) {
 		}
 		err = v.processLeafCreation(ctx, ev)
 		require.NoError(t, err)
-		AssertLogsContain(t, logsHook, "New leaf appended")
+		AssertLogsContain(t, logsHook, "Processing new leaf from the protocol")
 		AssertLogsContain(t, logsHook, "preparing to defend")
 	})
 	t.Run("fork leads validator to challenge leaf", func(t *testing.T) {
@@ -161,7 +161,7 @@ func Test_processLeafCreation(t *testing.T) {
 		}
 		err = v.processLeafCreation(ctx, ev)
 		require.NoError(t, err)
-		AssertLogsContain(t, logsHook, "New leaf appended")
+		AssertLogsContain(t, logsHook, "Processing new leaf from the protocol")
 		AssertLogsContain(t, logsHook, "Initiating challenge")
 	})
 }
@@ -232,10 +232,10 @@ func Test_findLatestValidAssertion(t *testing.T) {
 		v, p, s := setupValidator(t)
 		assertions := setupAssertions(10)
 		for _, a := range assertions {
-			v.assertions[a.SequenceNum] = &protocol.CreateLeafEvent{
+			v.assertions[a.SequenceNum] = []*protocol.CreateLeafEvent{{
 				StateCommitment: a.StateCommitment,
 				SeqNum:          a.SequenceNum,
-			}
+			}}
 			s.On("HasStateCommitment", ctx, a.StateCommitment).Return(true)
 		}
 		p.On("LatestConfirmed", tx).Return(assertions[0])
@@ -248,10 +248,10 @@ func Test_findLatestValidAssertion(t *testing.T) {
 		v, p, s := setupValidator(t)
 		assertions := setupAssertions(10)
 		for i, a := range assertions {
-			v.assertions[a.SequenceNum] = &protocol.CreateLeafEvent{
+			v.assertions[a.SequenceNum] = []*protocol.CreateLeafEvent{{
 				StateCommitment: a.StateCommitment,
 				SeqNum:          a.SequenceNum,
-			}
+			}}
 			if i <= 5 {
 				s.On("HasStateCommitment", ctx, a.StateCommitment).Return(true)
 			} else {


### PR DESCRIPTION
While working on fuzz tests, I encountered the following invariants. This PR makes updates based on invariant and prompts the following questions.

1. The validator stores new leaf event in a map keyed by the height. I don't think it's entirely impossible to two events to have the same height. In this version, we should change the map to the event(s) keyed by the height.  `map[uint64]*protocol.CreateLeafEvent` -> `map[uint64][]*protocol.CreateLeafEvent`

2. We don't want to challenge when receiving two nearly identical events that are the same state sequence numbers and same state commitments. The stakes could be the same, or it could be different, but in this scenario, we should no-op

3. I'm not entirely sure about the defense path. It seems odd that we can defend even if there's no challenge. Should we simplify this and only defend based on the new challenge events?
 
