### PR TITLE
Enable assertion staker to create challenge on self

### DIFF
--- a/protocol/assertions.go
+++ b/protocol/assertions.go
@@ -485,11 +485,6 @@ func (parent *Assertion) CreateChallenge(tx *ActiveTx, ctx context.Context, chal
 	if parent.secondChildCreationTime.IsNone() {
 		return nil, ErrInvalid
 	}
-	if !parent.Staker.IsNone() {
-		if parent.Staker.Unwrap() == challenger {
-			return nil, ErrCannotChallengeOwnLeaf
-		}
-	}
 	root := &ChallengeVertex{
 		challenge:   nil,
 		SequenceNum: 0,


### PR DESCRIPTION
Something smells odd if we don't allow the staker who created the assertion to create challenge. In the following scenario, `staker_a` should be able to create a challenge on `A`
```
    /------ B (first child, staker_b)
A(staker_a) 
    \------ C (staker_a)
```