### PR TITLE
Validator: use on-chain time reference

### DIFF
--- a/protocol/assertions.go
+++ b/protocol/assertions.go
@@ -82,6 +82,7 @@ type EventProvider interface {
 // and a previous assertion.
 type AssertionManager interface {
 	Inbox() *Inbox
+	TimeReference() util.TimeReference
 	NumAssertions(tx *ActiveTx) uint64
 	AssertionBySequenceNum(tx *ActiveTx, seqNum AssertionSequenceNumber) (*Assertion, error)
 	ChallengeByCommitHash(tx *ActiveTx, commitHash ChallengeCommitHash) (*Challenge, error)

--- a/testing/mocks/mocks.go
+++ b/testing/mocks/mocks.go
@@ -68,6 +68,10 @@ func (m *MockProtocol) Call(clo func(*protocol.ActiveTx, protocol.OnChainProtoco
 	return clo(&protocol.ActiveTx{}, m)
 }
 
+func (m *MockProtocol) TimeReference() util.TimeReference {
+	return util.NewRealTimeReference()
+}
+
 func (m *MockProtocol) SubscribeChainEvents(ctx context.Context, ch chan<- protocol.AssertionChainEvent) {
 }
 

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -109,6 +109,13 @@ func New(
 	stateManager statemanager.Manager,
 	opts ...Opt,
 ) (*Validator, error) {
+	var timeRef util.TimeReference
+	if err := chain.Tx(func(tx *protocol.ActiveTx, p protocol.OnChainProtocol) error {
+		timeRef = p.TimeReference()
+		return nil
+	}); err != nil {
+		return nil, err
+	}
 	v := &Validator{
 		chain:                                  chain,
 		stateManager:                           stateManager,
@@ -118,7 +125,7 @@ func New(
 		createdLeaves:                          make(map[common.Hash]*protocol.Assertion),
 		sequenceNumbersByParentStateCommitment: make(map[common.Hash][]protocol.AssertionSequenceNumber),
 		assertions:                             make(map[protocol.AssertionSequenceNumber]*protocol.CreateLeafEvent),
-		timeRef:                                util.NewRealTimeReference(),
+		timeRef:                                timeRef,
 		challengeVertexWakeInterval:            time.Millisecond * 100,
 	}
 	for _, o := range opts {


### PR DESCRIPTION
It's best for the validator to follow and use the same time reference that's on the chain and part of the protocol. We don't want any disparity here, using different time references while the validator is following the on-chain progress could become many sources of bugs. This requires one on-chain call to get the time reference when the validator is initialized 