### PR TITLE
Vertex: can't confirm if parent has subchallenge

### DIFF
--- a/protocol/assertions.go
+++ b/protocol/assertions.go
@@ -865,6 +865,9 @@ func (v *ChallengeVertex) ConfirmForPsTimer(tx *ActiveTx) error {
 	if v.status != PendingAssertionState {
 		return errors.Wrapf(ErrWrongState, fmt.Sprintf("Status: %d", v.status))
 	}
+	if !v.Prev.Unwrap().subChallenge.IsNone() {
+		return errors.Wrap(ErrInvalidOp, "predecessor contains sub-challenge")
+	}
 	if v.Prev.Unwrap().status != ConfirmedAssertionState {
 		return errors.Wrapf(ErrWrongPredecessorState, fmt.Sprintf("State: %d", v.Prev.Unwrap().status))
 	}
@@ -886,6 +889,9 @@ func (v *ChallengeVertex) ConfirmForChallengeDeadline(tx *ActiveTx) error {
 	tx.verifyReadWrite()
 	if v.status != PendingAssertionState {
 		return errors.Wrapf(ErrWrongState, fmt.Sprintf("Status: %d", v.status))
+	}
+	if !v.Prev.Unwrap().subChallenge.IsNone() {
+		return errors.Wrap(ErrInvalidOp, "predecessor contains sub-challenge")
 	}
 	if v.Prev.Unwrap().status != ConfirmedAssertionState {
 		return errors.Wrapf(ErrWrongPredecessorState, fmt.Sprintf("State: %d", v.Prev.Unwrap().status))


### PR DESCRIPTION
Per spec, we can't confirm a challenge vertex under time-based conditions if the predecessor has a sub-challenge. This PR adds the missing checks. 

```
- V’s predecessor has been confirmed, and
- either:
    - V’s predecessor has a sub-challenge, and that sub-challenge has reported V as its winner, or
    - V’s predecessor does not have a sub-challenge, and either:
``` 