### PR TITLE
Vertex: confirm challenge deadline presumptive only

### DIFF
--- a/protocol/assertions.go
+++ b/protocol/assertions.go
@@ -890,6 +890,9 @@ func (v *ChallengeVertex) ConfirmForChallengeDeadline(tx *ActiveTx) error {
 	if v.Prev.Unwrap().status != ConfirmedAssertionState {
 		return errors.Wrapf(ErrWrongPredecessorState, fmt.Sprintf("State: %d", v.Prev.Unwrap().status))
 	}
+	if v != v.Prev.Unwrap().PresumptiveSuccessor.Unwrap() {
+		return errors.Wrap(ErrInvalidOp, "Vertex is not the presumptive successor")
+	}
 	chain := v.challenge.Unwrap().rootAssertion.Unwrap().chain
 	chalPeriod := chain.challengePeriod
 	if !chain.timeReference.Get().After(v.challenge.Unwrap().creationTime.Add(2 * chalPeriod)) {


### PR DESCRIPTION
Per spec, to confirm a vertex through challenge deadline condition, the vertex itself has to be the presumptive successor of the parent. 
ex:
`the challenge’s end time has been reached, and V is the presumptive successor of V’s predecessor, `