### PR TITLE
Add mock execution engine, to support challenges over execution

### DIFF
--- a/execution/execution_engine.go
+++ b/execution/execution_engine.go
@@ -1,0 +1,166 @@
+package execution
+
+import (
+	"encoding/binary"
+	"errors"
+	"github.com/OffchainLabs/new-rollup-exploration/util"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// Capsule API description:
+//
+// BlockGenerator generates the blocks that make up a chain.
+// NewBlockGenerator(maxInstructionsPerBlock uint64) creates a block generator
+//      each block will use up to maxInstructionsPerBlock instructions of execution (randomly varying)
+//
+// blockGenerator.BlockHash(blockNum) gets the block hash of blockNum
+// blockGenerator.NewExecutionEngine(blockNum) creates an execution engine for the state transition function
+//      execution that creates blockNum (starting with the state at blockNum-1
+//
+// executionEngine.NumSteps() returns the number of steps of execution to create that block
+// executionEngine.StateAfter(num) returns the ExecutionState after executing num instructions (or error)
+//
+// executionState.Hash() gets the state root of executionState
+// executionState.NextState() gets the execution state after executing one instruction from executionState
+// executionState.OneStepProof() generates a one-step proof for executing one instruction from executionState
+//
+// VerifyOneStepProof(beforeStateRoot, claimedAfterStateRoot, proof) verifies a one-step proof
+
+var OutOfBoundsError = errors.New("instruction number out of bounds")
+
+type BlockGenerator struct {
+	stateRoots              []common.Hash
+	maxInstructionsPerBlock uint64
+}
+
+func NewBlockGenerator(maxInstructionsPerBlock uint64) *BlockGenerator {
+	return &BlockGenerator{
+		stateRoots:              []common.Hash{util.HashForUint(0)},
+		maxInstructionsPerBlock: maxInstructionsPerBlock,
+	}
+}
+
+func (gen *BlockGenerator) BlockHash(blockNum uint64) common.Hash {
+	for uint64(len(gen.stateRoots)) <= blockNum {
+		gen.stateRoots = append(
+			gen.stateRoots,
+			crypto.Keccak256Hash(gen.stateRoots[len(gen.stateRoots)-1].Bytes()),
+		)
+	}
+	return gen.stateRoots[blockNum]
+}
+
+func (gen *BlockGenerator) NewExecutionEngine(blockNum uint64) (*ExecutionEngine, error) {
+	if blockNum == 0 {
+		return nil, errors.New("tried to make execution engine for genesis block")
+	}
+	startStateRoot := gen.BlockHash(blockNum - 1)
+	endStateRoot := gen.BlockHash(blockNum)
+	numSteps := binary.BigEndian.Uint64(crypto.Keccak256(startStateRoot.Bytes())[:8]) % (1 + gen.maxInstructionsPerBlock)
+	return &ExecutionEngine{
+		startStateRoot: startStateRoot,
+		endStateRoot:   endStateRoot,
+		numSteps:       numSteps,
+	}, nil
+}
+
+type ExecutionEngine struct {
+	startStateRoot common.Hash
+	endStateRoot   common.Hash
+	numSteps       uint64
+}
+
+func (engine *ExecutionEngine) serialize() []byte {
+	ret := []byte{}
+	ret = append(ret, engine.startStateRoot.Bytes()...)
+	ret = append(ret, engine.endStateRoot.Bytes()...)
+	ret = append(ret, binary.BigEndian.AppendUint64([]byte{}, engine.numSteps)...)
+	return ret
+}
+
+func deserializeExecutionEngine(buf []byte) (*ExecutionEngine, error) {
+	if len(buf) != 32+32+8 {
+		return nil, errors.New("deserialization error")
+	}
+	return &ExecutionEngine{
+		startStateRoot: common.BytesToHash(buf[:32]),
+		endStateRoot:   common.BytesToHash(buf[32:64]),
+		numSteps:       binary.BigEndian.Uint64(buf[64:]),
+	}, nil
+}
+
+func (engine *ExecutionEngine) internalHash() common.Hash {
+	return crypto.Keccak256Hash(engine.serialize())
+}
+
+type ExecutionState struct {
+	engine  *ExecutionEngine
+	stepNum uint64
+}
+
+func (engine *ExecutionEngine) NumSteps() uint64 {
+	return engine.numSteps
+}
+
+func (engine *ExecutionEngine) StateAfter(num uint64) (*ExecutionState, error) {
+	if num > engine.numSteps {
+		return nil, OutOfBoundsError
+	}
+	return &ExecutionState{
+		engine:  engine,
+		stepNum: num,
+	}, nil
+}
+
+func (execState *ExecutionState) IsStopped() bool {
+	return execState.stepNum == execState.engine.numSteps
+}
+
+func (execState *ExecutionState) Hash() common.Hash {
+	if execState.IsStopped() {
+		return execState.engine.endStateRoot
+	}
+	return crypto.Keccak256Hash(binary.BigEndian.AppendUint64(execState.engine.internalHash().Bytes(), execState.stepNum))
+}
+
+func (execState *ExecutionState) NextState() (*ExecutionState, error) {
+	if execState.IsStopped() {
+		return nil, OutOfBoundsError
+	}
+	return &ExecutionState{
+		engine:  execState.engine,
+		stepNum: execState.stepNum + 1,
+	}, nil
+}
+
+func (execState *ExecutionState) OneStepProof() ([]byte, error) {
+	if execState.IsStopped() {
+		return nil, OutOfBoundsError
+	}
+	ret := execState.engine.serialize()
+	ret = append(ret, binary.BigEndian.AppendUint64([]byte{}, execState.stepNum)...)
+	return ret, nil
+}
+
+func VerifyOneStepProof(beforeStateRoot common.Hash, claimedAfterStateRoot common.Hash, proof []byte) bool {
+	if len(proof) < 8 {
+		return false
+	}
+	engine, err := deserializeExecutionEngine(proof[:len(proof)-8])
+	if err != nil {
+		return false
+	}
+	beforeState := ExecutionState{
+		engine:  engine,
+		stepNum: binary.BigEndian.Uint64(proof[len(proof)-8:]),
+	}
+	if beforeState.Hash() != beforeStateRoot {
+		return false
+	}
+	afterState, err := beforeState.NextState()
+	if err != nil {
+		return false
+	}
+	return afterState.Hash() == claimedAfterStateRoot
+}

--- a/execution/execution_engine_test.go
+++ b/execution/execution_engine_test.go
@@ -1,0 +1,87 @@
+package execution
+
+import "testing"
+
+func TestExecutionEngine(t *testing.T) {
+	maxInstructions := uint64(71)
+	blockGen := NewBlockGenerator(maxInstructions)
+	bh0 := blockGen.BlockHash(0)
+	bh1 := blockGen.BlockHash(1)
+	bh99 := blockGen.BlockHash(99)
+	if bh0 == bh1 || bh0 == bh99 || bh1 == bh99 {
+		t.Fatal()
+	}
+
+	engine99, err := blockGen.NewExecutionEngine(99)
+	if err != nil {
+		t.Fatal(err)
+	}
+	numSteps := engine99.NumSteps()
+	if numSteps == 0 || numSteps > maxInstructions {
+		t.Fatal(numSteps)
+	}
+
+	for i := uint64(0); i < numSteps; i++ {
+		thisState, err := engine99.StateAfter(i)
+		if err != nil {
+			t.Fatal(err, i)
+		}
+		nextState, err := thisState.NextState()
+		if err != nil {
+			t.Fatal(err, i)
+		}
+		nextDirect, err := engine99.StateAfter(i + 1)
+		if err != nil {
+			t.Fatal(err, i)
+		}
+		if nextState.Hash() != nextDirect.Hash() {
+			t.Fatal(i)
+		}
+		osp, err := thisState.OneStepProof()
+		if err != nil {
+			t.Fatal(err, i)
+		}
+		if !VerifyOneStepProof(thisState.Hash(), nextState.Hash(), osp) {
+			t.Fatal(i)
+		}
+
+		// verify that bad proofs get rejected
+		fakeProof := append([]byte{}, osp...)
+		fakeProof = append(fakeProof, 0)
+		if VerifyOneStepProof(thisState.Hash(), nextState.Hash(), fakeProof) {
+			t.Fatal(i)
+		}
+
+		fakeProof = append([]byte{}, osp...)
+		fakeProof[19] ^= 1
+		if VerifyOneStepProof(thisState.Hash(), nextState.Hash(), fakeProof) {
+			t.Fatal(i)
+		}
+
+		fakeProof = append([]byte{}, osp...)
+		fakeProof[19+32] ^= 1
+		if VerifyOneStepProof(thisState.Hash(), nextState.Hash(), fakeProof) {
+			t.Fatal(i)
+		}
+
+		fakeProof = append([]byte{}, osp...)
+		fakeProof[64+3] ^= 1
+		if VerifyOneStepProof(thisState.Hash(), nextState.Hash(), fakeProof) {
+			t.Fatal(i)
+		}
+
+		fakeProof = append([]byte{}, osp...)
+		fakeProof = fakeProof[len(fakeProof)-1:]
+		if VerifyOneStepProof(thisState.Hash(), nextState.Hash(), fakeProof) {
+			t.Fatal(i)
+		}
+	}
+
+	// check for expected errors
+	if _, err := engine99.StateAfter(engine99.NumSteps() + 1); err == nil {
+		t.Fatal()
+	}
+	if _, err := blockGen.NewExecutionEngine(0); err == nil {
+		t.Fatal()
+	}
+}


### PR DESCRIPTION
This adds a mock execution engine, which creates pseudo-execution states within a block, and supports creation and checking of one-step proofs over those pseudo-executions.

A capsule description of the API is in a block comment at the top of `execution_engine.go`