### PR TITLE
Fix mini-stake refund

### DIFF
--- a/protocol/assertions.go
+++ b/protocol/assertions.go
@@ -595,6 +595,7 @@ type Challenge struct {
 	WinnerAssertion       util.Option[*Assertion]
 	rootVertex            util.Option[*ChallengeVertex]
 	latestConfirmedVertex util.Option[*ChallengeVertex]
+	leafVertexCount       uint64
 	creationTime          time.Time
 	includedHistories     map[common.Hash]bool
 	nextSequenceNum       VertexSequenceNumber
@@ -737,6 +738,8 @@ func (c *Challenge) AddLeaf(tx *ActiveTx, assertion *Assertion, history util.His
 	h := ChallengeCommitHash(c.rootAssertion.Unwrap().StateCommitment.Hash())
 	c.rootAssertion.Unwrap().chain.challengesByCommitHash[h] = c
 	c.rootAssertion.Unwrap().chain.challengeVerticesByCommitHash[h][VertexCommitHash(leaf.Commitment.Hash())] = leaf
+	c.leafVertexCount++
+
 	return leaf, nil
 }
 
@@ -987,7 +990,11 @@ func (v *ChallengeVertex) ConfirmForChallengeDeadline(tx *ActiveTx) error {
 func (v *ChallengeVertex) _confirm(tx *ActiveTx) {
 	v.Status = ConfirmedAssertionState
 	if v.isLeaf {
-		v.Challenge.Unwrap().rootAssertion.Unwrap().chain.AddToBalance(tx, v.Validator, ChallengeVertexStake)
+		refund := big.NewInt(0)
+		leafCount := int64(v.Challenge.Unwrap().leafVertexCount)
+		refund.Mul(ChallengeVertexStake, big.NewInt(leafCount+1))
+		refund.Div(refund, big.NewInt(2))
+		v.Challenge.Unwrap().rootAssertion.Unwrap().chain.AddToBalance(tx, v.Validator, refund)
 		v.Challenge.Unwrap().WinnerAssertion = v.winnerIfConfirmed
 	}
 }

--- a/protocol/assertions_test.go
+++ b/protocol/assertions_test.go
@@ -136,7 +136,10 @@ func TestAssertionChain(t *testing.T) {
 
 		timeRef.Add(testChallengePeriod)
 		require.NoError(t, chal1.ConfirmForPsTimer(tx))
-		require.Equal(t, ChallengeVertexStake, chain.GetBalance(tx, chal1.Validator)) // Should receive challenge vertex stake back.
+
+		half := big.NewInt(0).Div(ChallengeVertexStake, big.NewInt(2))
+		want := big.NewInt(0).Add(half, ChallengeVertexStake)
+		require.Equal(t, want, chain.GetBalance(tx, chal1.Validator)) // Should receive own mini stake plus half of others.
 		require.NoError(t, branch1.ConfirmForWin(tx))
 		require.Equal(t, branch1, chain.LatestConfirmed(tx))
 


### PR DESCRIPTION
When we refund, we give back its stake `S`, but it should be `(L+1)S / 2` where `L` is the total leaves. That is all of their stake plus half of every other stake. This was pointed out in the draft paper. This PR changed to the new refund formula. 

Note: There's no easy way to retrieve the number of leaves in a challenge. I added a new field to track it. I figured a simple uint64 may be ok, and it may be more valuable down the line for other purposes 