### PR TITLE
[Credits to @yahgwai] Internal Lib Functions for Contracts

### DIFF
--- a/contracts/test/ChallengeManagerE2E.t.sol
+++ b/contracts/test/ChallengeManagerE2E.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 import "forge-std/Test.sol";
 import "../src/DataEntities.sol";
 import "./MockAssertionChain.sol";
-import "../src/ChallengeManager.sol";
+import "../src/ChallengeManagerImpl.sol";
 import "../src/osp/IOneStepProofEntry.sol";
 
 contract MockOneStepProofEntry is IOneStepProofEntry {
@@ -36,10 +36,10 @@ contract ChallengeManagerE2ETest is Test {
     uint256 miniStakeVal = 1 ether;
     uint256 challengePeriod = 1000;
 
-    function deploy() internal returns (MockAssertionChain, ChallengeManager, bytes32) {
+    function deploy() internal returns (MockAssertionChain, ChallengeManagerImpl, bytes32) {
         MockAssertionChain assertionChain = new MockAssertionChain();
-        ChallengeManager challengeManager =
-            new ChallengeManager(assertionChain, miniStakeVal, challengePeriod, new MockOneStepProofEntry());
+        ChallengeManagerImpl challengeManager =
+            new ChallengeManagerImpl(assertionChain, miniStakeVal, challengePeriod, new MockOneStepProofEntry());
         bytes32 genesis = assertionChain.addAssertionUnsafe(0, 0, 0, genesisHash, 0);
 
         return (assertionChain, challengeManager, genesis);
@@ -47,9 +47,9 @@ contract ChallengeManagerE2ETest is Test {
 
     function deployAndInitChallenge()
         internal
-        returns (MockAssertionChain, ChallengeManager, bytes32, bytes32, bytes32, bytes32)
+        returns (MockAssertionChain, ChallengeManagerImpl, bytes32, bytes32, bytes32, bytes32)
     {
-        (MockAssertionChain assertionChain, ChallengeManager challengeManager, bytes32 genesis) = deploy();
+        (MockAssertionChain assertionChain, ChallengeManagerImpl challengeManager, bytes32 genesis) = deploy();
 
         bytes32 a1 = assertionChain.addAssertion(genesis, height1, inboxSeenCount1, h1, 0);
         bytes32 a2 = assertionChain.addAssertion(genesis, height1, inboxSeenCount1, h2, 0);
@@ -60,7 +60,7 @@ contract ChallengeManagerE2ETest is Test {
     }
 
     function testCanConfirmPs() public {
-        (, ChallengeManager challengeManager,, bytes32 a1,, bytes32 challengeId) = deployAndInitChallenge();
+        (, ChallengeManagerImpl challengeManager,, bytes32 a1,, bytes32 challengeId) = deployAndInitChallenge();
 
         bytes32 v1Id = challengeManager.addLeaf{value: miniStakeVal}(
             AddLeafArgs({
@@ -85,7 +85,7 @@ contract ChallengeManagerE2ETest is Test {
     }
 
     function testCanConfirmSubChallenge() public {
-        (, ChallengeManager challengeManager,, bytes32 a1, bytes32 a2, bytes32 blockChallengeId) =
+        (, ChallengeManagerImpl challengeManager,, bytes32 a1, bytes32 a2, bytes32 blockChallengeId) =
             deployAndInitChallenge();
 
         bytes32 v1Id = challengeManager.addLeaf{value: miniStakeVal}(
@@ -245,7 +245,7 @@ contract ChallengeManagerE2ETest is Test {
     }
 
     function testCanConfirmFromOneStep() public {
-        (, ChallengeManager challengeManager,, bytes32 a1, bytes32 a2, bytes32 blockChallengeId) =
+        (, ChallengeManagerImpl challengeManager,, bytes32 a1, bytes32 a2, bytes32 blockChallengeId) =
             deployAndInitChallenge();
 
         (bytes32[5] memory blockWinners, bytes32[5] memory blockLosers) = addLeafsAndBisectToSubChallenge(
@@ -271,7 +271,7 @@ contract ChallengeManagerE2ETest is Test {
 
         challengeManager.executeOneStep(
             smallStepWinners[0],
-            ChallengeManager.OneStepData({
+            ChallengeManagerImpl.OneStepData({
                 execCtx: ExecutionContext({
                     maxInboxMessagesRead: 0,
                     bridge: IBridge(address(0))


### PR DESCRIPTION
This PR from @yahgwai moves all lib functions in the challenge manager to be internal to remove the need for delegate calls and library linkages at deployment