### PR TITLE
Assertion: invalidate before confirm

### DIFF
--- a/protocol/assertion-chain/assertion_chain.go
+++ b/protocol/assertion-chain/assertion_chain.go
@@ -165,6 +165,11 @@ func (ac *AssertionChain) CreateSuccessionChallenge(assertionId common.Hash) (*C
 
 // Confirm creates a confirmation for the given assertion.
 func (a *Assertion) Confirm() error {
+	// Refresh the inner fields of our before making on-chain calls.
+	if err := a.invalidate(); err != nil {
+		return err
+	}
+
 	_, err := a.chain.writer.ConfirmAssertion(a.chain.txOpts, a.id)
 	switch {
 	case err == nil:


### PR DESCRIPTION
We should invalidate before confirming an assertion