### PR TITLE
CreateSuccessionChallenge: don't hardcore assertion id to empty

### DIFF
--- a/protocol/sol-implementation/assertion_chain.go
+++ b/protocol/sol-implementation/assertion_chain.go
@@ -6,11 +6,10 @@ package solimpl
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"math/big"
 	"strings"
 	"time"
-
-	"fmt"
 
 	"github.com/OffchainLabs/challenge-protocol-v2/solgen/go/rollupgen"
 	"github.com/OffchainLabs/challenge-protocol-v2/util"
@@ -184,21 +183,21 @@ func (ac *AssertionChain) CreateAssertion(
 }
 
 // CreateSuccessionChallenge creates a succession challenge
-func (ac *AssertionChain) CreateSuccessionChallenge(ctx context.Context, assertionId uint64) (*Challenge, error) {
+func (ac *AssertionChain) CreateSuccessionChallenge(ctx context.Context, assertionNum uint64, assertionHash common.Hash) (*Challenge, error) {
 	_, err := transact(ctx, ac.backend, func() (*types.Transaction, error) {
 		return ac.userLogic.CreateChallenge(
 			ac.txOpts,
-			assertionId,
+			assertionNum,
 		)
 	})
-	if err2 := handleCreateSuccessionChallengeError(err, assertionId); err2 != nil {
+	if err2 := handleCreateSuccessionChallengeError(err, assertionNum); err2 != nil {
 		return nil, err2
 	}
 	manager, err := ac.ChallengeManager()
 	if err != nil {
 		return nil, err
 	}
-	challengeId, err := manager.CalculateChallengeId(ctx, common.Hash{}, BlockChallenge)
+	challengeId, err := manager.CalculateChallengeId(ctx, assertionHash, BlockChallenge)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/sol-implementation/assertion_chain_test.go
+++ b/protocol/sol-implementation/assertion_chain_test.go
@@ -232,7 +232,7 @@ func TestCreateSuccessionChallenge(t *testing.T) {
 	ctx := context.Background()
 	t.Run("assertion does not exist", func(t *testing.T) {
 		chain, _, _, _ := setupAssertionChainWithChallengeManager(t)
-		_, err := chain.CreateSuccessionChallenge(ctx, 2)
+		_, err := chain.CreateSuccessionChallenge(ctx, 2, common.Hash{})
 		require.ErrorIs(t, err, ErrInvalidChildren)
 	})
 	t.Run("at least two children required", func(t *testing.T) {
@@ -271,7 +271,7 @@ func TestCreateSuccessionChallenge(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		_, err = chain.CreateSuccessionChallenge(ctx, 0)
+		_, err = chain.CreateSuccessionChallenge(ctx, 0, common.Hash{})
 		require.ErrorIs(t, err, ErrInvalidChildren)
 	})
 	t.Run("assertion already rejected", func(t *testing.T) {
@@ -336,10 +336,10 @@ func TestCreateSuccessionChallenge(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		_, err = chain.CreateSuccessionChallenge(ctx, 0)
+		_, err = chain.CreateSuccessionChallenge(ctx, 0, common.Hash{})
 		require.NoError(t, err)
 
-		_, err = chain.CreateSuccessionChallenge(ctx, 0)
+		_, err = chain.CreateSuccessionChallenge(ctx, 0, common.Hash{})
 		require.ErrorIs(t, err, ErrAlreadyExists)
 	})
 }

--- a/protocol/sol-implementation/challenge_test.go
+++ b/protocol/sol-implementation/challenge_test.go
@@ -2,13 +2,14 @@ package solimpl
 
 import (
 	"context"
+	"math/big"
+	"testing"
+
 	"github.com/OffchainLabs/challenge-protocol-v2/solgen/go/rollupgen"
 	"github.com/OffchainLabs/challenge-protocol-v2/util"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
-	"math/big"
-	"testing"
 )
 
 func TestChallenge_BlockChallenge_AddLeaf(t *testing.T) {
@@ -161,7 +162,7 @@ func setupTopLevelFork(
 	)
 	require.NoError(t, err)
 
-	challenge, err := chain2.CreateSuccessionChallenge(ctx, 0)
+	challenge, err := chain2.CreateSuccessionChallenge(ctx, 0, common.Hash{})
 	require.NoError(t, err)
 	return a1, a2, challenge, chain1, chain2
 }


### PR DESCRIPTION
When we calculate challenge ID, `CalculateChallengeId` is always taking in `common.hash` as assertion ID. I don't think that's fixed so we should take it as an argument. I also renamed the old assertion ID to the assertion number for clarity. ID is usually referred as `common.hash`