### PR TITLE
Update go root implementation to match the solidity one

### DIFF
--- a/util/proof.go
+++ b/util/proof.go
@@ -29,14 +29,20 @@ func (me MerkleExpansion) Clone() MerkleExpansion {
 func (me MerkleExpansion) Root() common.Hash {
 	accum := common.Hash{}
 	empty := true
-	for _, h := range me {
+	for i, h := range me {
 		if empty {
 			if h != (common.Hash{}) {
 				empty = false
 				accum = h
+
+				if i != (len(me) - 1) {
+					accum = crypto.Keccak256Hash(accum.Bytes(), (common.Hash{}).Bytes())
+				}
 			}
+		} else if h != (common.Hash{}) {
+			accum = crypto.Keccak256Hash(h.Bytes(), accum.Bytes())
 		} else {
-			accum = crypto.Keccak256Hash(accum.Bytes(), h.Bytes())
+			accum = crypto.Keccak256Hash(accum.Bytes(), (common.Hash{}).Bytes())
 		}
 	}
 	return accum
@@ -134,7 +140,7 @@ func VerifyPrefixProof(pre, post HistoryCommitment, proof []common.Hash) error {
 	expHeight := pre.Height
 	expansion, numRead := MerkleExpansionFromCompact(proof, expHeight)
 	proof = proof[numRead:]
-	height := post.Height + 1
+	height := post.Height
 	for expHeight < height {
 		if len(proof) == 0 {
 			return ErrIncorrectProof

--- a/util/proof_test.go
+++ b/util/proof_test.go
@@ -68,7 +68,6 @@ func compUncompTest(t *testing.T, me MerkleExpansion) {
 }
 
 func TestMerkleProof(t *testing.T) {
-	t.Skip("Prefix proofs tested elsewhere, need to investigate off by one")
 	for _, c := range []struct {
 		lo uint64
 		hi uint64
@@ -102,7 +101,6 @@ func TestMerkleProof(t *testing.T) {
 }
 
 func TestMerkleProofBackend(t *testing.T) {
-	t.Skip("Prefix proofs tested elsewhere, need to investigate off by one")
 	for _, c := range []struct {
 		lo uint64
 		hi uint64


### PR DESCRIPTION
The solidity implementation differs from the go implementation in order to match an existing construction of the root used in outbox proving.