### PR TITLE
Unskip Older Integration Test

### DIFF
--- a/validator/challenges_test.go
+++ b/validator/challenges_test.go
@@ -89,7 +89,7 @@ func TestChallengeProtocol_AliceAndBob(t *testing.T) {
 		// Bob bisects from 3 to 2, is presumptive.
 		// Alice merges from 3 to 2.
 		// Both challengers are now at a one-step fork, we now await subchallenge resolution.
-		cfg.expectedLeavesAdded = 6 // TODO: Rename to leaf
+		cfg.expectedLeavesAdded = 6
 		cfg.expectedBisections = 12
 		cfg.expectedMerges = 6
 		hook := test.NewGlobal()


### PR DESCRIPTION
Now that flakes are fixed from #140 , we can unskip some older integration test in the validator that checks Alice and Bob opening assertions at height 255