### PR TITLE
util/inclusion-proofs: Add tests for invalid input validation

### DIFF
--- a/util/inclusion-proofs/inclusion_proofs_test.go
+++ b/util/inclusion-proofs/inclusion_proofs_test.go
@@ -77,7 +77,7 @@ func TestMerkleProof(t *testing.T) {
 		_, err = CalculateRootFromProof(make([]common.Hash, 257), 0, common.Hash{})
 		require.Equal(t, ErrProofTooLong, err)
 
-		// ... but proof with more exactly 256 elements should be OK.
+		// ... but proof with exactly 256 elements should be OK.
 		_, err = CalculateRootFromProof(make([]common.Hash, 256), 0, common.Hash{})
 		require.NotEqual(t, ErrProofTooLong, err)
 	})


### PR DESCRIPTION
As title describes. Some code branches were not well tested so I've added some tests here to ensure the validation is hit in a unit test.

This also puts 100% code coverage on inclusion_proofs.go.
