### PR TITLE
util/prefix-proofs: add validation testing to Root() function [TOB-ARBCH-1]

### DIFF
--- a/util/prefix-proofs/merkle_expansions_test.go
+++ b/util/prefix-proofs/merkle_expansions_test.go
@@ -3,24 +3,17 @@ package prefixproofs
 import (
 	"testing"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 )
 
-var nullHash = common.Hash{}
-
 func TestMerkleExpansion(t *testing.T) {
 	me := NewEmptyMerkleExpansion()
-	root, err := Root(me)
-	require.NoError(t, err)
-	require.Equal(t, nullHash, root)
-	compUncompTest(t, me)
 
 	h0 := crypto.Keccak256Hash([]byte{0})
-	me, err = AppendCompleteSubTree(me, 0, h0)
+	me, err := AppendCompleteSubTree(me, 0, h0)
 	require.NoError(t, err)
-	root, err = Root(me)
+	root, err := Root(me)
 	require.NoError(t, err)
 	require.Equal(t, h0, root)
 	compUncompTest(t, me)

--- a/util/prefix-proofs/prefix_proofs.go
+++ b/util/prefix-proofs/prefix_proofs.go
@@ -111,6 +111,9 @@ func Root(me []common.Hash) (common.Hash, error) {
 	if uint64(len(me)) >= MAX_LEVEL {
 		return common.Hash{}, ErrLevelTooHigh
 	}
+	if uint64(len(me)) == 0 {
+		return common.Hash{}, ErrRootForEmpty
+	}
 
 	var accum common.Hash
 	for i := 0; i < len(me); i++ {

--- a/util/prefix-proofs/prefix_proofs_test.go
+++ b/util/prefix-proofs/prefix_proofs_test.go
@@ -23,6 +23,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestRoot(t *testing.T) {
+	t.Run("tree too large", func(t *testing.T) {
+		tree := make([]common.Hash, 64)
+		_, err := prefixproofs.Root(tree)
+		require.Equal(t, prefixproofs.ErrLevelTooHigh, err)
+	})
+	t.Run("empty tree", func(t *testing.T) {
+		tree := make([]common.Hash, 0)
+		_, err := prefixproofs.Root(tree)
+		require.Equal(t, prefixproofs.ErrRootForEmpty, err)
+	})
+	t.Run("single element returns itself", func(t *testing.T) {
+		tree := make([]common.Hash, 1)
+		tree[0] = common.HexToHash("0x1234")
+		root, err := prefixproofs.Root(tree)
+		require.NoError(t, err)
+		require.Equal(t, tree[0], root)
+	})
+}
+
 func TestVerifyPrefixProof_GoSolidityEquivalence(t *testing.T) {
 	ctx := context.Background()
 	hashes := make([]common.Hash, 10)


### PR DESCRIPTION
I found that the Root function was missing some validation that exists in the solidity equivalent so this PR brings that to parity. 
