### PR TITLE
TOB-ARBCH-11: fix Incorrect state transition in `edgeAtOneStepProof` 

### DIFF
--- a/validator/edge_tracker.go
+++ b/validator/edge_tracker.go
@@ -71,7 +71,7 @@ func (et *edgeTracker) act(ctx context.Context) error {
 		if err := et.submitOneStepProof(ctx); err != nil {
 			return errors.Wrap(err, "could not submit one step proof")
 		}
-		return et.fsm.Do(edgeAwaitSubchallengeResolution{})
+		return et.fsm.Do(edgeConfirm{})
 	// Edge tracker should add a subchallenge level zero leaf.
 	case edgeAddingSubchallengeLeaf:
 		event, ok := current.SourceEvent.(edgeOpenSubchallengeLeaf)


### PR DESCRIPTION
Fixes `TOB-ARBCH-11`, where at `edgeAtOneStepProof`, we should either submit one step proof or confirm