### PR TITLE
Align post assertion interval

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"math/big"
-
 	"time"
 
 	"github.com/OffchainLabs/challenge-protocol-v2/protocol"
@@ -31,7 +30,7 @@ var (
 	// How often the validator polls the chain to see if new assertions have been posted.
 	checkForAssertionsInteral = time.Second
 	// How often the validator will post its latest assertion to the chain.
-	postNewAssertionInterval = time.Hour
+	postNewAssertionInterval = time.Second * 5
 )
 
 func main() {

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -99,7 +99,6 @@ func New(
 		chain:                     chain,
 		stateManager:              stateManager,
 		address:                   common.Address{},
-		postAssertionsInterval:    time.Second * 5,
 		timeRef:                   util.NewRealTimeReference(),
 		rollupAddr:                rollupAddr,
 		edgeTrackerWakeInterval:   time.Millisecond * 100,


### PR DESCRIPTION
Post assertion interval defined at the `main` level is one hour. The interval is also redefined at the validator initialization level for five seconds. This PR aligns the main level to five seconds. Let me know if it should be an hour instead