### PR TITLE
Can one step proof: return err on same lengths

### DIFF
--- a/validator/edge_tracker.go
+++ b/validator/edge_tracker.go
@@ -479,7 +479,7 @@ func canOneStepProve(edge protocol.SpecEdge) (bool, error) {
 	end, _ := edge.EndCommitment()
 	// Can never happen in the protocol, but added as an additional defensive check.
 	if start >= end {
-		return false, fmt.Errorf("start height %d cannot be > end height %d", start, end)
+		return false, fmt.Errorf("start height %d cannot be >= end height %d", start, end)
 	}
 	return end-start == 1 && edge.GetType() == protocol.SmallStepChallengeEdge, nil
 }


### PR DESCRIPTION
It seems to me it would make sense to return error if `start` and `end` are the same lengths for one-step proof or else we'll reach silent errors on the downstream moves for the state machines. I think this is the "safer" option. Curious to hear feedback