### PR TITLE
validator: Use 5s default value for postAssertionsInterval

### DIFF
--- a/validator/validator.go
+++ b/validator/validator.go
@@ -103,6 +103,7 @@ func New(
 		rollupAddr:                rollupAddr,
 		edgeTrackerWakeInterval:   time.Millisecond * 100,
 		newAssertionCheckInterval: time.Second,
+		postAssertionsInterval:    time.Second * 5,
 	}
 	for _, o := range opts {
 		o(v)


### PR DESCRIPTION
Otherwise, the validator panics if started without providing a PostAssertionsInterval option.

```
panic: non-positive interval for NewTicker

goroutine 3140 [running]:
time.NewTicker(0xc0001b4000?)
        GOROOT/src/time/tick.go:24 +0x10f
github.com/OffchainLabs/challenge-protocol-v2/validator.(*Validator).postAssertionsPeriodically(0xc0001b4000, {0xd186b8, 0xc000190000})
        validator/validator.go:148 +0x1af
created by github.com/OffchainLabs/challenge-protocol-v2/validator.(*Validator).Start
        validator/validator.go:137 +0x12f
```
