### PR TITLE
Use valid child assertion from parent

### DIFF
--- a/validator/challenges.go
+++ b/validator/challenges.go
@@ -14,7 +14,7 @@ import (
 // and starting a challenge transaction. If the challenge creation is successful, we add a leaf
 // with an associated history commitment to it and spawn a challenge tracker in the background.
 func (v *Validator) challengeAssertion(ctx context.Context, parentSeqNum protocol.AssertionSequenceNumber) error {
-	num, err := v.assertionFromParent(ctx, parentSeqNum)
+	num, err := v.validChildFromParent(ctx, parentSeqNum)
 	if err != nil {
 		return err
 	}

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -254,11 +254,11 @@ func (v *Validator) findLatestValidAssertion(ctx context.Context) (protocol.Asse
 	return bestAssertion, nil
 }
 
-// assertionFromParent returns the assertion number of a child of the parent assertion number.
+// validChildFromParent returns the assertion number of a child of the parent assertion number.
 // The assertion must be valid and exists in state manager by `ExecutionStateBlockHeight` validation.
 // It returns the first assertion number that is a child of the parent assertion number. This assumes there's no two children of the same parent.
 // If no such assertion exists, an error gets returned.
-func (v *Validator) assertionFromParent(ctx context.Context, parentAssertionNumber protocol.AssertionSequenceNumber) (protocol.AssertionSequenceNumber, error) {
+func (v *Validator) validChildFromParent(ctx context.Context, parentAssertionNumber protocol.AssertionSequenceNumber) (protocol.AssertionSequenceNumber, error) {
 	numAssertions, err := v.chain.NumAssertions(ctx)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
When challenging an assertion, we should use the valid child from the parent. The way it works
- Check if there's another child
- If yes: get the parent
- From parent number to latest number
   - Check if the assertion is built from parent
       - If yes: does state mgmt has it?
           -If yes: return 

Return error if no valid children is found  