### PR TITLE
Optimize latest valid assertion

### DIFF
--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -136,15 +136,8 @@ func setupAssertions(ctx context.Context, p *mocks.MockProtocol, s *mocks.MockSt
 			MockSeqNum:     protocol.AssertionSequenceNumber(i),
 			MockHeight:     uint64(i),
 			MockStateHash:  mockHash,
-			Prev:           util.Some(assertions[i-1].(*mocks.MockAssertion)),
 			MockPrevSeqNum: protocol.AssertionSequenceNumber(i - 1),
 		})
-		assertions = append(assertions, assertion)
-		p.On(
-			"AssertionBySequenceNum",
-			ctx,
-			protocol.AssertionSequenceNumber(i),
-		).Return(assertion, nil)
 		mockState := rollupgen.ExecutionState{
 			MachineStatus: uint8(protocol.MachineStatusFinished),
 			GlobalState: rollupgen.GlobalState(protocol.GoGlobalState{


### PR DESCRIPTION
Can't help but make a simple optimization to `findLatestValidAssertion` even though it's not intended for production. Nitro will take care of this I presume. Instead of looping `s := latestConfirmed + 1; s < protocol.AssertionSequenceNumber(numAssertions); s++`, we go backwards `s := numAssertions - 1; s > uint64(latestConfirmed); s--` and return the first valid assertion