### PR TITLE
Close anvil client upon test completion

### DIFF
--- a/testing/endtoend/basic_local_test.go
+++ b/testing/endtoend/basic_local_test.go
@@ -2,6 +2,7 @@ package endtoend
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -49,6 +50,11 @@ func TestChallengeProtocol_AliceAndBob_AnvilLocal(t *testing.T) {
 	if err := be.Start(); err != nil {
 		t.Fatal(err)
 	}
+	defer func() {
+		if err := be.Stop(); err != nil {
+			t.Log(fmt.Errorf("error stopping backend: %v", err))
+		}
+	}()
 
 	scenarios := []*ChallengeScenario{
 		{

--- a/testing/endtoend/internal/backend/anvil_local.go
+++ b/testing/endtoend/internal/backend/anvil_local.go
@@ -173,6 +173,7 @@ func (a *AnvilLocal) Start() error {
 // Stop the backend and terminate the anvil process.
 func (a *AnvilLocal) Stop() error {
 	a.cancel()
+	a.rpc.Close()
 	return a.cmd.Process.Kill()
 }
 


### PR DESCRIPTION
When testing e2e, the anvil client remains open after the test completes. I couldn't figure out what we using the 8545 port when running a geth node:
```
Fatal: Error starting protocol stack: listen tcp 127.0.0.1:8545: bind: address already in use

lsof -i tcp:8545
COMMAND   PID USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
anvil   21737    t    9u  IPv4 0x90f4b3a758f9321b      0t0  TCP localhost:8545 (LISTEN)
```

This PR adds RPC close to `Stop()` and call a defer stop for `TestChallengeProtocol_AliceAndBob_AnvilLocal`