### PR TITLE
Sync top level edges

### DIFF
--- a/protocol/sol-implementation/types.go
+++ b/protocol/sol-implementation/types.go
@@ -22,6 +22,18 @@ type Assertion struct {
 	id              uint64
 }
 
+func (a *Assertion) Height() (uint64, error) {
+	genesis, err := a.chain.rollup.GetAssertion(&bind.CallOpts{}, uint64(1))
+	if err != nil {
+		return 0, err
+	}
+	inner, err := a.inner()
+	if err != nil {
+		return 0, err
+	}
+	return inner.CreatedAtBlock - genesis.CreatedAtBlock, nil
+}
+
 func (a *Assertion) SeqNum() protocol.AssertionSequenceNumber {
 	return protocol.AssertionSequenceNumber(a.id)
 }
@@ -45,12 +57,12 @@ func (a *Assertion) StateHash() (common.Hash, error) {
 	return inner.StateHash, nil
 }
 
-func (a *Assertion) IsFirstChild() (bool, error) {
+func (a *Assertion) CreatedAtBlock() (uint64, error) {
 	inner, err := a.inner()
 	if err != nil {
-		return false, err
+		return 0, err
 	}
-	return inner.IsFirstChild, nil
+	return inner.CreatedAtBlock, nil
 }
 
 func (a *Assertion) inner() (*rollupgen.AssertionNode, error) {

--- a/protocol/spec_interfaces.go
+++ b/protocol/spec_interfaces.go
@@ -7,7 +7,6 @@ import (
 	"github.com/OffchainLabs/challenge-protocol-v2/solgen/go/rollupgen"
 	"github.com/OffchainLabs/challenge-protocol-v2/util"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
 )
 
 const GenesisAssertionSeqNum = AssertionSequenceNumber(1)
@@ -29,10 +28,11 @@ type Protocol interface {
 // chain state created by a validator that stakes on their claim.
 // Assertions can be challenged.
 type Assertion interface {
+	Height() (uint64, error)
 	SeqNum() AssertionSequenceNumber
 	PrevSeqNum() (AssertionSequenceNumber, error)
 	StateHash() (common.Hash, error)
-	IsFirstChild() (bool, error)
+	CreatedAtBlock() (uint64, error)
 }
 
 // AssertionCreatedInfo from an event creation.
@@ -42,13 +42,9 @@ type AssertionCreatedInfo struct {
 	AfterState          rollupgen.ExecutionState
 	InboxMaxCount       *big.Int
 	AfterInboxBatchAcc  common.Hash
+	ExecutionHash       common.Hash
 	AssertionHash       common.Hash
 	WasmModuleRoot      common.Hash
-}
-
-func (i AssertionCreatedInfo) ExecutionHash() common.Hash {
-	afterGlobalStateHash := GoGlobalStateFromSolidity(i.AfterState.GlobalState).Hash()
-	return crypto.Keccak256Hash(append([]byte{i.AfterState.MachineStatus}, afterGlobalStateHash.Bytes()...))
 }
 
 // AssertionChain can manage assertions in the protocol and retrieve


### PR DESCRIPTION
This PR begins to implement initial sync for the challenge manager.  `syncChallenges` is a function a challenge manager will call upon start-up. Using the following algorithm:
- Loop through edge added events from last confirmed block number to latest block number
- Get the edge ID
- Get the parent assertion
- Spin up an edge tracker go routine