### PR TITLE
feat(chain-abstraction): check before on-chain transaction

### DIFF
--- a/chain-abstraction/sol-implementation/assertion_chain.go
+++ b/chain-abstraction/sol-implementation/assertion_chain.go
@@ -29,7 +29,6 @@ var (
 	ErrTooLate          = errors.New("too late to create assertion sibling")
 	ErrTooSoon          = errors.New("too soon to confirm assertion")
 	ErrInvalidHeight    = errors.New("invalid assertion height")
-	ErrContainsChildren = errors.New("edge contains children")
 )
 
 var assertionCreatedId common.Hash

--- a/chain-abstraction/sol-implementation/edge_challenge_manager.go
+++ b/chain-abstraction/sol-implementation/edge_challenge_manager.go
@@ -173,7 +173,7 @@ func (e *SpecEdge) Bisect(
 		if lowerEdge.IsNone() {
 			return nil, nil, errors.New("could not refresh lower edge after bisecting, got empty result")
 		}
-		return upperEdge.Unwrap(), lowerEdge.Unwrap(), ErrContainsChildren
+		return lowerEdge.Unwrap(), upperEdge.Unwrap(), nil
 	}
 
 	_, err = transact(ctx, e.manager.backend, e.manager.reader, func() (*types.Transaction, error) {

--- a/chain-abstraction/sol-implementation/edge_challenge_manager_test.go
+++ b/chain-abstraction/sol-implementation/edge_challenge_manager_test.go
@@ -217,16 +217,13 @@ func TestEdgeChallengeManager_Bisect(t *testing.T) {
 		require.NoError(t, err)
 		honestProof, err := honestStateManager.PrefixProofUpToBatch(ctx, 0, protocol.LevelZeroBlockEdgeHeight/2, protocol.LevelZeroBlockEdgeHeight, 1)
 		require.NoError(t, err)
-		_, _, err = honestEdge.Bisect(ctx, honestBisectCommit.Merkle, honestProof)
+		lower, upper, err := honestEdge.Bisect(ctx, honestBisectCommit.Merkle, honestProof)
 		require.NoError(t, err)
-	})
-	t.Run("Contains children", func(t *testing.T) {
-		honestBisectCommit, err := honestStateManager.HistoryCommitmentUpToBatch(ctx, 0, protocol.LevelZeroBlockEdgeHeight/2, 1)
+
+		gotLower, gotUpper, err := honestEdge.Bisect(ctx, honestBisectCommit.Merkle, honestProof)
 		require.NoError(t, err)
-		honestProof, err := honestStateManager.PrefixProofUpToBatch(ctx, 0, protocol.LevelZeroBlockEdgeHeight/2, protocol.LevelZeroBlockEdgeHeight, 1)
-		require.NoError(t, err)
-		_, _, err = honestEdge.Bisect(ctx, honestBisectCommit.Merkle, honestProof)
-		require.ErrorIs(t, err, solimpl.ErrContainsChildren)
+		require.Equal(t, lower.Id(), gotLower.Id())
+		require.Equal(t, upper.Id(), gotUpper.Id())
 	})
 }
 


### PR DESCRIPTION
Return earlier if the following on-chain move transaction has already been done to achieve the same outcome. This is to avoid wasting gas.

- For confirmation, we check if the edge is confirmed
- For bisect, we check if the edge has either of upper and lower child
- For one step proof, we check if the edge is confirmed
- For adding layer zero edge, we pre-compute the edge ID and check if the edge exists