### PR TITLE
refactor: rename "prev" assertion id

### DIFF
--- a/chain-abstraction/interfaces.go
+++ b/chain-abstraction/interfaces.go
@@ -69,7 +69,7 @@ type AssertionChain interface {
 	// Mutating methods.
 	CreateAssertion(
 		ctx context.Context,
-		prevAssertionCreationInfo *AssertionCreatedInfo,
+		assertionCreationInfo *AssertionCreatedInfo,
 		postState *ExecutionState,
 	) (Assertion, error)
 
@@ -241,7 +241,7 @@ type ReadOnlyEdge interface {
 	MiniStaker() option.Option[common.Address]
 	// The assertion id of the parent assertion that originated the challenge
 	// at the top-level.
-	PrevAssertionId(ctx context.Context) (AssertionId, error)
+	AssertionId(ctx context.Context) (AssertionId, error)
 	// The time in seconds an edge has been unrivaled.
 	TimeUnrivaled(ctx context.Context) (uint64, error)
 	// Whether or not an edge has rivals.

--- a/chain-abstraction/sol-implementation/assertion_chain.go
+++ b/chain-abstraction/sol-implementation/assertion_chain.go
@@ -145,7 +145,7 @@ func (a *AssertionChain) WasmModuleRoot(ctx context.Context) ([32]byte, error) {
 // and a commitment to a post-state.
 func (a *AssertionChain) CreateAssertion(
 	ctx context.Context,
-	prevAssertionCreationInfo *protocol.AssertionCreatedInfo,
+	assertionCreationInfo *protocol.AssertionCreatedInfo,
 	postState *protocol.ExecutionState,
 ) (protocol.Assertion, error) {
 	stake, err := a.userLogic.BaseStake(&bind.CallOpts{Context: ctx})
@@ -173,14 +173,14 @@ func (a *AssertionChain) CreateAssertion(
 			newOpts,
 			rollupgen.AssertionInputs{
 				BeforeStateData: rollupgen.BeforeStateData{
-					PrevPrevAssertionHash: prevAssertionCreationInfo.ParentAssertionHash,
-					SequencerBatchAcc:     prevAssertionCreationInfo.AfterInboxBatchAcc,
+					PrevPrevAssertionHash: assertionCreationInfo.ParentAssertionHash,
+					SequencerBatchAcc:     assertionCreationInfo.AfterInboxBatchAcc,
 					RequiredStake:         stake,
 					ChallengeManager:      chalManager.Address(),
 					ConfirmPeriodBlocks:   chalPeriodBlocks,
 					WasmRoot:              wasmModuleRoot,
 				},
-				BeforeState: prevAssertionCreationInfo.AfterState,
+				BeforeState: assertionCreationInfo.AfterState,
 				AfterState:  postState.AsSolidityStruct(),
 			},
 			// TODO(RJ): Use the expected assertion hash as a sanity check.
@@ -244,7 +244,7 @@ func (a *AssertionChain) TopLevelAssertion(ctx context.Context, edgeId protocol.
 	if edgeOpt.IsNone() {
 		return protocol.AssertionId{}, errors.New("edge was nil")
 	}
-	return edgeOpt.Unwrap().PrevAssertionId(ctx)
+	return edgeOpt.Unwrap().AssertionId(ctx)
 }
 
 func (a *AssertionChain) TopLevelClaimHeights(ctx context.Context, edgeId protocol.EdgeId) (*protocol.OriginHeights, error) {
@@ -364,7 +364,7 @@ func handleCreateAssertionError(err error, blockHash common.Hash) error {
 			"commit block hash %#x",
 			blockHash,
 		)
-	case strings.Contains(errS, "Previous assertion does not exist"):
+	case strings.Contains(errS, "Assertion does not exist"):
 		return ErrPrevDoesNotExist
 	case strings.Contains(errS, "Too late to create sibling"):
 		return ErrTooLate

--- a/chain-abstraction/sol-implementation/assertion_chain_test.go
+++ b/chain-abstraction/sol-implementation/assertion_chain_test.go
@@ -24,7 +24,7 @@ func TestCreateAssertion(t *testing.T) {
 			latestBlockHash = backend.Commit()
 		}
 
-		prevCreationInfo := &protocol.AssertionCreatedInfo{
+		createdInfo := &protocol.AssertionCreatedInfo{
 			AfterState: (&protocol.ExecutionState{
 				GlobalState:   protocol.GoGlobalState{},
 				MachineStatus: protocol.MachineStatusFinished,
@@ -39,10 +39,10 @@ func TestCreateAssertion(t *testing.T) {
 			},
 			MachineStatus: protocol.MachineStatusFinished,
 		}
-		_, err := chain.CreateAssertion(ctx, prevCreationInfo, postState)
+		_, err := chain.CreateAssertion(ctx, createdInfo, postState)
 		require.NoError(t, err)
 
-		_, err = chain.CreateAssertion(ctx, prevCreationInfo, postState)
+		_, err = chain.CreateAssertion(ctx, createdInfo, postState)
 		require.ErrorContains(t, err, "ALREADY_STAKED")
 	})
 	t.Run("can create fork", func(t *testing.T) {
@@ -53,7 +53,7 @@ func TestCreateAssertion(t *testing.T) {
 			backend.Commit()
 		}
 
-		prevCreationInfo := &protocol.AssertionCreatedInfo{
+		creationInfo := &protocol.AssertionCreatedInfo{
 			AfterState: (&protocol.ExecutionState{
 				GlobalState:   protocol.GoGlobalState{},
 				MachineStatus: protocol.MachineStatusFinished,
@@ -68,7 +68,7 @@ func TestCreateAssertion(t *testing.T) {
 			},
 			MachineStatus: protocol.MachineStatusFinished,
 		}
-		_, err := assertionChain.CreateAssertion(ctx, prevCreationInfo, postState)
+		_, err := assertionChain.CreateAssertion(ctx, creationInfo, postState)
 		require.NoError(t, err)
 	})
 }

--- a/chain-abstraction/sol-implementation/edge_challenge_manager.go
+++ b/chain-abstraction/sol-implementation/edge_challenge_manager.go
@@ -39,7 +39,7 @@ func (e *SpecEdge) EndCommitment() (protocol.Height, common.Hash) {
 	return protocol.Height(e.inner.EndHeight.Uint64()), e.inner.EndHistoryRoot
 }
 
-func (e *SpecEdge) PrevAssertionId(ctx context.Context) (protocol.AssertionId, error) {
+func (e *SpecEdge) AssertionId(ctx context.Context) (protocol.AssertionId, error) {
 	return e.manager.caller.GetPrevAssertionId(&bind.CallOpts{Context: ctx}, e.id)
 }
 

--- a/chain-abstraction/sol-implementation/edge_challenge_manager_test.go
+++ b/chain-abstraction/sol-implementation/edge_challenge_manager_test.go
@@ -541,9 +541,9 @@ func TestEdgeChallengeManager_ConfirmByOneStepProof(t *testing.T) {
 		fromSmallStep := uint64(0)
 		toSmallStep := uint64(1)
 
-		prevId, err := honestEdge.PrevAssertionId(ctx)
+		id, err := honestEdge.AssertionId(ctx)
 		require.NoError(t, err)
-		parentAssertionCreationInfo, err := chain.ReadAssertionCreationInfo(ctx, prevId)
+		parentAssertionCreationInfo, err := chain.ReadAssertionCreationInfo(ctx, id)
 		require.NoError(t, err)
 
 		requiredStake, err := chain.BaseStake(ctx)

--- a/challenge-manager/chain-watcher/watcher.go
+++ b/challenge-manager/chain-watcher/watcher.go
@@ -311,7 +311,7 @@ func (w *Watcher) processEdgeAddedEvent(
 	}
 	edge := edgeOpt.Unwrap()
 
-	assertionId, err := edge.PrevAssertionId(ctx)
+	assertionId, err := edge.AssertionId(ctx)
 	if err != nil {
 		return err
 	}
@@ -491,7 +491,7 @@ func (w *Watcher) processEdgeConfirmation(
 		return errors.New("no edge found")
 	}
 	edge := edgeOpt.Unwrap()
-	prevAssertionId, err := edge.PrevAssertionId(ctx)
+	assertionId, err := edge.AssertionId(ctx)
 	if err != nil {
 		return err
 	}
@@ -499,12 +499,12 @@ func (w *Watcher) processEdgeConfirmation(
 		return nil
 	}
 	claimId := edge.ClaimId().Unwrap()
-	chal, ok := w.challenges.TryGet(prevAssertionId)
+	chal, ok := w.challenges.TryGet(assertionId)
 	if !ok {
 		return nil
 	}
 	chal.confirmedLevelZeroEdgeClaimIds.Insert(claimId)
-	w.challenges.Put(prevAssertionId, chal)
+	w.challenges.Put(assertionId, chal)
 	return nil
 }
 

--- a/challenge-manager/chain-watcher/watcher_test.go
+++ b/challenge-manager/chain-watcher/watcher_test.go
@@ -34,7 +34,7 @@ func TestWatcher_processEdgeConfirmation(t *testing.T) {
 
 	edge.On("ClaimId").Return(option.Some(protocol.ClaimId(assertionId)))
 	edge.On(
-		"PrevAssertionId",
+		"AssertionId",
 		ctx,
 	).Return(assertionId, nil)
 
@@ -108,7 +108,7 @@ func TestWatcher_processEdgeAddedEvent(t *testing.T) {
 	edge.On("StartCommitment").Return(protocol.Height(0), startCommit)
 	edge.On("EndCommitment").Return(protocol.Height(4), endCommit)
 	edge.On(
-		"PrevAssertionId",
+		"AssertionId",
 		ctx,
 	).Return(assertionId, nil)
 

--- a/challenge-manager/challenge-tree/tree.go
+++ b/challenge-manager/challenge-tree/tree.go
@@ -39,7 +39,7 @@ type HonestChallengeTree struct {
 }
 
 func New(
-	prevAssertionId protocol.AssertionId,
+	assertionId protocol.AssertionId,
 	metadataReader MetadataReader,
 	histChecker l2stateprovider.HistoryChecker,
 	validatorName string,
@@ -47,7 +47,7 @@ func New(
 	return &HonestChallengeTree{
 		edges:                         threadsafe.NewMap[protocol.EdgeId, protocol.SpecEdge](),
 		mutualIds:                     threadsafe.NewMap[protocol.MutualId, *threadsafe.Map[protocol.EdgeId, creationTime]](),
-		topLevelAssertionId:           prevAssertionId,
+		topLevelAssertionId:           assertionId,
 		honestBlockChalLevelZeroEdge:  option.None[protocol.ReadOnlyEdge](),
 		honestBigStepLevelZeroEdges:   threadsafe.NewSlice[protocol.ReadOnlyEdge](),
 		honestSmallStepLevelZeroEdges: threadsafe.NewSlice[protocol.ReadOnlyEdge](),

--- a/challenge-manager/challenge-tree/tree_test.go
+++ b/challenge-manager/challenge-tree/tree_test.go
@@ -264,7 +264,7 @@ func (*edge) MiniStaker() option.Option[common.Address] {
 
 // The assertion id of the parent assertion that originated the challenge
 // at the top-level.
-func (*edge) PrevAssertionId(_ context.Context) (protocol.AssertionId, error) {
+func (*edge) AssertionId(_ context.Context) (protocol.AssertionId, error) {
 	return protocol.AssertionId{}, errors.New("unimplemented")
 }
 

--- a/challenge-manager/edge_sync.go
+++ b/challenge-manager/edge_sync.go
@@ -49,7 +49,7 @@ func (v *Manager) getEdgeTrackers(ctx context.Context, edges []protocol.SpecEdge
 	for i, edge := range edges {
 		// Retry until you get the previous assertion ID.
 		assertionId, err = retry.UntilSucceeds(ctx, func() (protocol.AssertionId, error) {
-			return edge.PrevAssertionId(ctx)
+			return edge.AssertionId(ctx)
 		})
 		if err != nil {
 			return nil, err

--- a/challenge-manager/edge_sync_test.go
+++ b/challenge-manager/edge_sync_test.go
@@ -15,7 +15,7 @@ func Test_getEdgeTrackers(t *testing.T) {
 
 	v, m, s := setupValidator(t)
 	edge := &mocks.MockSpecEdge{}
-	edge.On("PrevAssertionId", ctx).Return(protocol.AssertionId{}, nil)
+	edge.On("AssertionId", ctx).Return(protocol.AssertionId{}, nil)
 	m.On("ReadAssertionCreationInfo", ctx, protocol.AssertionId{}).Return(&protocol.AssertionCreatedInfo{InboxMaxCount: big.NewInt(100)}, nil)
 	s.On("ExecutionStateBlockHeight", ctx, &protocol.ExecutionState{}).Return(uint64(1), true)
 

--- a/challenge-manager/edge_tracker.go
+++ b/challenge-manager/edge_tracker.go
@@ -357,11 +357,11 @@ func (et *edgeTracker) submitOneStepProof(ctx context.Context) error {
 	toBigStep := fromBigStep + 1
 	pc, _ := et.edge.StartCommitment()
 
-	prevAssertionId, err := et.edge.PrevAssertionId(ctx)
+	assertionId, err := et.edge.AssertionId(ctx)
 	if err != nil {
 		return err
 	}
-	parentAssertionCreationInfo, err := et.cfg.chain.ReadAssertionCreationInfo(ctx, prevAssertionId)
+	parentAssertionCreationInfo, err := et.cfg.chain.ReadAssertionCreationInfo(ctx, assertionId)
 	if err != nil {
 		return err
 	}

--- a/testing/mocks/mocks.go
+++ b/testing/mocks/mocks.go
@@ -319,7 +319,7 @@ func (m *MockSpecEdge) TopLevelClaimHeight(ctx context.Context) (*protocol.Origi
 	args := m.Called(ctx)
 	return args.Get(0).(*protocol.OriginHeights), args.Error(1)
 }
-func (m *MockSpecEdge) PrevAssertionId(ctx context.Context) (protocol.AssertionId, error) {
+func (m *MockSpecEdge) AssertionId(ctx context.Context) (protocol.AssertionId, error) {
 	args := m.Called(ctx)
 	return args.Get(0).(protocol.AssertionId), args.Error(1)
 }
@@ -456,10 +456,10 @@ func (m *MockProtocol) ReadAssertionCreationInfo(
 // Mutating methods.
 func (m *MockProtocol) CreateAssertion(
 	ctx context.Context,
-	prevAssertionCreationInfo *protocol.AssertionCreatedInfo,
+	assertionCreationInfo *protocol.AssertionCreatedInfo,
 	postState *protocol.ExecutionState,
 ) (protocol.Assertion, error) {
-	args := m.Called(ctx, prevAssertionCreationInfo, postState)
+	args := m.Called(ctx, assertionCreationInfo, postState)
 	return args.Get(0).(protocol.Assertion), args.Error(1)
 }
 


### PR DESCRIPTION
Remove `prev` prefix for assertion ID and creation info for clarify improvement