### PR TITLE
test(e2e): add assertion confirmation to sync test

### DIFF
--- a/testing/endtoend/basic_local_test.go
+++ b/testing/endtoend/basic_local_test.go
@@ -262,6 +262,8 @@ func TestSync_HonestBobStopsCharlieJoins(t *testing.T) {
 		}(),
 		Expectations: []expect{
 			expectLevelZeroBlockEdgeConfirmed,
+			expectAssertionConfirmedByChallengeWinner,
+			expectOneStepProofSuccessful,
 		},
 	}
 


### PR DESCRIPTION
Add `expectAssertionConfirmedByChallengeWinner` to e2e sync test