### PR TITLE
Use Prev Assertion Creation Info Config Details

### DIFF
--- a/chain-abstraction/interfaces.go
+++ b/chain-abstraction/interfaces.go
@@ -65,8 +65,6 @@ type AssertionChain interface {
 	GetAssertion(ctx context.Context, id AssertionId) (Assertion, error)
 	LatestConfirmed(ctx context.Context) (Assertion, error)
 	LatestCreatedAssertion(ctx context.Context) (Assertion, error)
-	BaseStake(ctx context.Context) (*big.Int, error)
-	WasmModuleRoot(ctx context.Context) ([32]byte, error)
 	ReadAssertionCreationInfo(
 		ctx context.Context, id AssertionId,
 	) (*AssertionCreatedInfo, error)

--- a/chain-abstraction/sol-implementation/assertion_chain.go
+++ b/chain-abstraction/sol-implementation/assertion_chain.go
@@ -132,14 +132,6 @@ func (a *AssertionChain) LatestConfirmed(ctx context.Context) (protocol.Assertio
 	return a.GetAssertion(ctx, res)
 }
 
-func (a *AssertionChain) BaseStake(ctx context.Context) (*big.Int, error) {
-	return a.userLogic.BaseStake(&bind.CallOpts{Context: ctx})
-}
-
-func (a *AssertionChain) WasmModuleRoot(ctx context.Context) ([32]byte, error) {
-	return a.userLogic.WasmModuleRoot(&bind.CallOpts{Context: ctx})
-}
-
 // CreateAssertion makes an on-chain claim given a previous assertion id, execution state,
 // and a commitment to a post-state.
 func (a *AssertionChain) CreateAssertion(
@@ -150,25 +142,12 @@ func (a *AssertionChain) CreateAssertion(
 	if !assertionCreationInfo.InboxMaxCount.IsUint64() {
 		return nil, errors.New("prev assertion creation info inbox max count not a uint64")
 	}
-	stake, err := a.userLogic.BaseStake(&bind.CallOpts{Context: ctx})
+	prevCreationInfo, err := a.ReadAssertionCreationInfo(ctx, protocol.AssertionId(assertionCreationInfo.ParentAssertionHash))
 	if err != nil {
-		return nil, errors.Wrap(err, "could not get current required stake")
+		return nil, err
 	}
 	newOpts := copyTxOpts(a.txOpts)
-	newOpts.Value = stake
-
-	chalManager, err := a.SpecChallengeManager(ctx)
-	if err != nil {
-		return nil, err
-	}
-	chalPeriodBlocks, err := chalManager.ChallengePeriodBlocks(ctx)
-	if err != nil {
-		return nil, err
-	}
-	wasmModuleRoot, err := a.userLogic.WasmModuleRoot(&bind.CallOpts{Context: ctx})
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get current required stake")
-	}
+	newOpts.Value = prevCreationInfo.RequiredStake
 	if !assertionCreationInfo.InboxMaxCount.IsUint64() {
 		return nil, errors.New("inbox max count was not a uint64")
 	}
@@ -180,10 +159,10 @@ func (a *AssertionChain) CreateAssertion(
 					PrevPrevAssertionHash: assertionCreationInfo.ParentAssertionHash,
 					SequencerBatchAcc:     assertionCreationInfo.AfterInboxBatchAcc,
 					ConfigData: rollupgen.ConfigData{
-						RequiredStake:       stake,
-						ChallengeManager:    chalManager.Address(),
-						ConfirmPeriodBlocks: chalPeriodBlocks,
-						WasmModuleRoot:      wasmModuleRoot,
+						RequiredStake:       prevCreationInfo.RequiredStake,
+						ChallengeManager:    prevCreationInfo.ChallengeManager,
+						ConfirmPeriodBlocks: prevCreationInfo.ConfirmPeriodBlocks,
+						WasmModuleRoot:      prevCreationInfo.WasmModuleRoot,
 						NextInboxPosition:   assertionCreationInfo.InboxMaxCount.Uint64(),
 					},
 				},

--- a/chain-abstraction/sol-implementation/edge_challenge_manager.go
+++ b/chain-abstraction/sol-implementation/edge_challenge_manager.go
@@ -525,9 +525,9 @@ func (cm *SpecChallengeManager) ConfirmEdgeByOneStepProof(
 					Proof:      oneStepData.Proof,
 				},
 				challengeV2gen.ConfigData{
-					WasmModuleRoot:      oneStepData.WasmModuleRoot,
+					WasmModuleRoot:      creationInfo.WasmModuleRoot,
 					RequiredStake:       creationInfo.RequiredStake,
-					ChallengeManager:    cm.addr,
+					ChallengeManager:    creationInfo.ChallengeManager,
 					ConfirmPeriodBlocks: creationInfo.ConfirmPeriodBlocks,
 					NextInboxPosition:   creationInfo.InboxMaxCount.Uint64(),
 				},

--- a/chain-abstraction/sol-implementation/edge_challenge_manager_test.go
+++ b/chain-abstraction/sol-implementation/edge_challenge_manager_test.go
@@ -545,20 +545,11 @@ func TestEdgeChallengeManager_ConfirmByOneStepProof(t *testing.T) {
 		parentAssertionCreationInfo, err := chain.ReadAssertionCreationInfo(ctx, id)
 		require.NoError(t, err)
 
-		requiredStake, err := chain.BaseStake(ctx)
-		require.NoError(t, err)
-
-		challengePeriod, err := challengeManager.ChallengePeriodBlocks(ctx)
-		require.NoError(t, err)
-
-		wasmRoot, err := chain.WasmModuleRoot(ctx)
-		require.NoError(t, err)
-
 		cfgSnapshot := &l2stateprovider.ConfigSnapshot{
-			RequiredStake:           requiredStake,
-			ChallengeManagerAddress: challengeManager.Address(),
-			ConfirmPeriodBlocks:     challengePeriod,
-			WasmModuleRoot:          wasmRoot,
+			RequiredStake:           parentAssertionCreationInfo.RequiredStake,
+			ChallengeManagerAddress: parentAssertionCreationInfo.ChallengeManager,
+			ConfirmPeriodBlocks:     parentAssertionCreationInfo.ConfirmPeriodBlocks,
+			WasmModuleRoot:          parentAssertionCreationInfo.WasmModuleRoot,
 			InboxMaxCount:           big.NewInt(1),
 		}
 

--- a/testing/mocks/mocks.go
+++ b/testing/mocks/mocks.go
@@ -3,7 +3,6 @@ package mocks
 import (
 	"context"
 	"errors"
-	"math/big"
 
 	protocol "github.com/OffchainLabs/challenge-protocol-v2/chain-abstraction"
 	"github.com/OffchainLabs/challenge-protocol-v2/containers/option"
@@ -400,16 +399,6 @@ type MockProtocol struct {
 func (m *MockProtocol) NumAssertions(ctx context.Context) (uint64, error) {
 	args := m.Called(ctx)
 	return args.Get(0).(uint64), args.Error(1)
-}
-
-func (m *MockProtocol) BaseStake(ctx context.Context) (*big.Int, error) {
-	args := m.Called(ctx)
-	return args.Get(0).(*big.Int), args.Error(1)
-}
-
-func (m *MockProtocol) WasmModuleRoot(ctx context.Context) ([32]byte, error) {
-	args := m.Called(ctx)
-	return args.Get(0).([32]byte), args.Error(1)
 }
 
 func (m *MockProtocol) GetAssertion(ctx context.Context, id protocol.AssertionId) (protocol.Assertion, error) {


### PR DESCRIPTION
In certain moves onchain, we are supposed to use the previous assertion's config info, such as the challenge manager, confirm period blocks, wasm module root, etc. instead of the current value of those items onchain. This PR fixes that problem