### PR TITLE
test: close anvil for charlie properly

### DIFF
--- a/testing/endtoend/basic_local_test.go
+++ b/testing/endtoend/basic_local_test.go
@@ -225,6 +225,9 @@ func TestSync_HonestBobStopsCharlieJoins(t *testing.T) {
 	be, err := backend.NewAnvilLocal(context.Background())
 	require.NoError(t, err)
 	require.NoError(t, be.Start())
+	defer func() {
+		require.NoError(t, be.Stop(), "error stopping backend")
+	}()
 
 	scenario := &ChallengeScenario{
 		Name: "two forked assertions at the same height",


### PR DESCRIPTION
`TestSync_HonestBobStopsCharlieJoins` did not properly close anvil backend 