### PR TITLE
chore(challenge-manager): rm redundant casting

### DIFF
--- a/challenge-manager/edge-tracker/fsm_states.go
+++ b/challenge-manager/edge-tracker/fsm_states.go
@@ -6,11 +6,11 @@ import (
 
 // Defines a state in a finite state machine that aids
 // in deciding a challenge edge tracker's actions.
-type edgeTrackerState uint8
+type EdgeTrackerState uint8
 
 const (
 	// Start state of 0 can never happen to avoid silly mistakes with default Go values.
-	_ edgeTrackerState = iota
+	_ EdgeTrackerState = iota
 	// The start state of the tracker.
 	edgeStarted
 	// The edge being tracked is at a one step proof.
@@ -27,7 +27,7 @@ const (
 )
 
 // String turns an edge tracker state into a readable string.
-func (s edgeTrackerState) String() string {
+func (s EdgeTrackerState) String() string {
 	switch s {
 	case edgeStarted:
 		return "started"

--- a/challenge-manager/edge-tracker/tracker.go
+++ b/challenge-manager/edge-tracker/tracker.go
@@ -70,7 +70,7 @@ func WithValidatorAddress(addr common.Address) Opt {
 	}
 }
 
-func WithFSMOpts(opts ...fsm.Opt[edgeTrackerAction, edgeTrackerState]) Opt {
+func WithFSMOpts(opts ...fsm.Opt[edgeTrackerAction, EdgeTrackerState]) Opt {
 	return func(et *Tracker) {
 		et.fsmOpts = opts
 	}
@@ -83,8 +83,8 @@ type HeightConfig struct {
 
 type Tracker struct {
 	edge             protocol.SpecEdge
-	fsm              *fsm.Fsm[edgeTrackerAction, edgeTrackerState]
-	fsmOpts          []fsm.Opt[edgeTrackerAction, edgeTrackerState]
+	fsm              *fsm.Fsm[edgeTrackerAction, EdgeTrackerState]
+	fsmOpts          []fsm.Opt[edgeTrackerAction, EdgeTrackerState]
 	actInterval      time.Duration
 	timeRef          utilTime.Reference
 	validatorName    string
@@ -164,7 +164,7 @@ func (et *Tracker) Spawn(ctx context.Context) {
 	}
 }
 
-func (et *Tracker) CurrentState() edgeTrackerState {
+func (et *Tracker) CurrentState() EdgeTrackerState {
 	return et.fsm.Current().State
 }
 

--- a/challenge-manager/edge-tracker/transition_table.go
+++ b/challenge-manager/edge-tracker/transition_table.go
@@ -5,15 +5,15 @@ import (
 )
 
 func newEdgeTrackerFsm(
-	startState edgeTrackerState,
-	fsmOpts ...fsm.Opt[edgeTrackerAction, edgeTrackerState],
-) (*fsm.Fsm[edgeTrackerAction, edgeTrackerState], error) {
-	transitions := []*fsm.Event[edgeTrackerAction, edgeTrackerState]{
+	startState EdgeTrackerState,
+	fsmOpts ...fsm.Opt[edgeTrackerAction, EdgeTrackerState],
+) (*fsm.Fsm[edgeTrackerAction, EdgeTrackerState], error) {
+	transitions := []*fsm.Event[edgeTrackerAction, EdgeTrackerState]{
 		{
 			// Returns the tracker to the very beginning. Several states can cause
 			// this, including challenge moves.
 			Typ: edgeBackToStart{},
-			From: []edgeTrackerState{
+			From: []EdgeTrackerState{
 				edgeBisecting,
 				edgeStarted,
 				edgeAtOneStepProof,
@@ -25,31 +25,31 @@ func newEdgeTrackerFsm(
 			// The tracker will take some action if it has reached a one-step-proof
 			// in a small step challenge.
 			Typ:  edgeHandleOneStepProof{},
-			From: []edgeTrackerState{edgeStarted},
+			From: []EdgeTrackerState{edgeStarted},
 			To:   edgeAtOneStepProof,
 		},
 		{
 			// The tracker will add a subchallenge leaf to its edge's subchallenge.
 			Typ:  edgeOpenSubchallengeLeaf{},
-			From: []edgeTrackerState{edgeStarted, edgeAddingSubchallengeLeaf},
+			From: []EdgeTrackerState{edgeStarted, edgeAddingSubchallengeLeaf},
 			To:   edgeAddingSubchallengeLeaf,
 		},
 		// Challenge moves.
 		{
 			Typ:  edgeBisect{},
-			From: []edgeTrackerState{edgeStarted},
+			From: []EdgeTrackerState{edgeStarted},
 			To:   edgeBisecting,
 		},
 		// Awaiting confirmation.
 		{
 			Typ:  edgeAwaitConfirmation{},
-			From: []edgeTrackerState{edgeStarted, edgeBisecting, edgeAddingSubchallengeLeaf, edgeConfirming},
+			From: []EdgeTrackerState{edgeStarted, edgeBisecting, edgeAddingSubchallengeLeaf, edgeConfirming},
 			To:   edgeConfirming,
 		},
 		// Terminal state.
 		{
 			Typ:  edgeConfirm{},
-			From: []edgeTrackerState{edgeStarted, edgeConfirming, edgeConfirmed, edgeAtOneStepProof},
+			From: []EdgeTrackerState{edgeStarted, edgeConfirming, edgeConfirmed, edgeAtOneStepProof},
 			To:   edgeConfirmed,
 		},
 	}

--- a/challenge-manager/manager_test.go
+++ b/challenge-manager/manager_test.go
@@ -34,14 +34,14 @@ func TestEdgeTracker_act(t *testing.T) {
 		tkr, _ := setupNonPSTracker(ctx, t)
 		err := tkr.Act(ctx)
 		require.NoError(t, err)
-		require.Equal(t, int(4), int(tkr.CurrentState()))
+		require.Equal(t, 4, int(tkr.CurrentState()))
 		err = tkr.Act(ctx)
 		require.NoError(t, err)
-		require.Equal(t, int(5), int(tkr.CurrentState()))
+		require.Equal(t, 5, int(tkr.CurrentState()))
 		logging.AssertLogsContain(t, hook, "Successfully bisected")
 		err = tkr.Act(ctx)
 		require.NoError(t, err)
-		require.Equal(t, int(5), int(tkr.CurrentState()))
+		require.Equal(t, 5, int(tkr.CurrentState()))
 	})
 }
 


### PR DESCRIPTION
Remove redundant casting and export `EdgeTrackerState` because `CurrentState()` exports it 