### PR TITLE
Add some commentary to challenge-manager packages, removed unused edgetracker.WithValidatorAddress

### DIFF
--- a/challenge-manager/chain-watcher/watcher.go
+++ b/challenge-manager/chain-watcher/watcher.go
@@ -1,6 +1,11 @@
 // Copyright 2023, Offchain Labs, Inc.
 // For license information, see https://github.com/offchainlabs/challenge-protocol-v2/blob/main/LICENSE
 
+// Package watcher implements the main monitoring logic for protocol validators.
+// The challenge watcher is a singleton service available to all spawned edge trackers
+// and it tracks common information such as the edges' ancestors and an edge's time unrivaled.
+//
+// See: [github.com/OffchainLabs/challenge-protocol-v2/challenge-manager/edge-tracker]
 package watcher
 
 import (

--- a/challenge-manager/challenges.go
+++ b/challenge-manager/challenges.go
@@ -46,7 +46,6 @@ func (m *Manager) ChallengeAssertion(ctx context.Context, id protocol.AssertionH
 		edgetracker.WithActInterval(m.edgeTrackerWakeInterval),
 		edgetracker.WithTimeReference(m.timeRef),
 		edgetracker.WithValidatorName(m.name),
-		edgetracker.WithValidatorAddress(m.address),
 	)
 	if err != nil {
 		return err

--- a/challenge-manager/manager.go
+++ b/challenge-manager/manager.go
@@ -251,7 +251,6 @@ func (m *Manager) getTrackerForEdge(ctx context.Context, edge protocol.SpecEdge)
 			},
 			edgetracker.WithActInterval(m.edgeTrackerWakeInterval),
 			edgetracker.WithTimeReference(m.timeRef),
-			edgetracker.WithValidatorAddress(m.address),
 			edgetracker.WithValidatorName(m.name),
 		)
 	})

--- a/challenge-manager/manager_test.go
+++ b/challenge-manager/manager_test.go
@@ -104,7 +104,6 @@ func setupNonPSTracker(ctx context.Context, t *testing.T) (*edgetracker.Tracker,
 			TopLevelClaimEndBatchCount: 1,
 		},
 		edgetracker.WithTimeReference(customTime.NewArtificialTimeReference()),
-		edgetracker.WithValidatorAddress(honestValidator.address),
 		edgetracker.WithValidatorName(honestValidator.name),
 	)
 	require.NoError(t, err)
@@ -131,7 +130,6 @@ func setupNonPSTracker(ctx context.Context, t *testing.T) (*edgetracker.Tracker,
 			TopLevelClaimEndBatchCount: 1,
 		},
 		edgetracker.WithTimeReference(customTime.NewArtificialTimeReference()),
-		edgetracker.WithValidatorAddress(evilValidator.address),
 		edgetracker.WithValidatorName(evilValidator.name),
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
I've added some commentary when reviewing the challenge-manager packages as I found some things lacking in description for godocs.

Please review that the commentary is accurate and sufficiently thorough. 

I've also removed an option to set the validator's address as it was never used and we did not have future plans for its use.
