### PR TITLE
Feat: assertion hash embeds common.Hash

### DIFF
--- a/assertions/poster_test.go
+++ b/assertions/poster_test.go
@@ -49,7 +49,7 @@ func Test_findLatestValidAssertion(t *testing.T) {
 }
 
 func mockId(x uint64) protocol.AssertionHash {
-	return protocol.AssertionHash(common.BytesToHash([]byte(fmt.Sprintf("%d", x))))
+	return protocol.AssertionHash{Hash: common.BytesToHash([]byte(fmt.Sprintf("%d", x)))}
 }
 
 func setupAssertions(

--- a/assertions/scanner.go
+++ b/assertions/scanner.go
@@ -156,7 +156,7 @@ func (s *Scanner) checkForAssertionAdded(
 			)
 		}
 		_, processErr := retry.UntilSucceeds(ctx, func() (bool, error) {
-			return true, s.ProcessAssertionCreation(ctx, it.Event.AssertionHash)
+			return true, s.ProcessAssertionCreation(ctx, protocol.AssertionHash{Hash: it.Event.AssertionHash})
 		})
 		if processErr != nil {
 			return processErr
@@ -175,7 +175,7 @@ func (s *Scanner) ProcessAssertionCreation(
 	if err != nil {
 		return err
 	}
-	prevAssertion, err := s.chain.GetAssertion(ctx, protocol.AssertionHash(creationInfo.ParentAssertionHash))
+	prevAssertion, err := s.chain.GetAssertion(ctx, protocol.AssertionHash{Hash: creationInfo.ParentAssertionHash})
 	if err != nil {
 		return err
 	}

--- a/assertions/scanner_test.go
+++ b/assertions/scanner_test.go
@@ -41,7 +41,7 @@ func TestScanner_ProcessAssertionCreation(t *testing.T) {
 		p := &mocks.MockProtocol{}
 		p.On("SpecChallengeManager", ctx).Return(&mocks.MockSpecChallengeManager{}, nil)
 		p.On("ReadAssertionCreationInfo", ctx, mockId(2)).Return(&protocol.AssertionCreatedInfo{
-			ParentAssertionHash: common.Hash(mockId(1)),
+			ParentAssertionHash: mockId(1).Hash,
 			AfterState:          rollupgen.ExecutionState{},
 		}, nil)
 		p.On("GetAssertion", ctx, mockId(2)).Return(ev, nil)
@@ -157,5 +157,5 @@ func setupChallengeManager(t *testing.T) (*challengemanager.Manager, *mocks.Mock
 }
 
 func mockId(x uint64) protocol.AssertionHash {
-	return protocol.AssertionHash(common.BytesToHash([]byte(fmt.Sprintf("%d", x))))
+	return protocol.AssertionHash{Hash: common.BytesToHash([]byte(fmt.Sprintf("%d", x)))}
 }

--- a/chain-abstraction/interfaces.go
+++ b/chain-abstraction/interfaces.go
@@ -16,7 +16,9 @@ import (
 
 // AssertionHash represents a unique identifier for an assertion
 // constructed as a keccak256 hash of some of its internals.
-type AssertionHash common.Hash
+type AssertionHash struct {
+	common.Hash
+}
 
 // Protocol --
 type Protocol interface {

--- a/chain-abstraction/sol-implementation/assertion_chain_test.go
+++ b/chain-abstraction/sol-implementation/assertion_chain_test.go
@@ -25,7 +25,7 @@ func TestCreateAssertion(t *testing.T) {
 
 	genesisHash, err := chain.GenesisAssertionHash(ctx)
 	require.NoError(t, err)
-	genesisInfo, err := chain.ReadAssertionCreationInfo(ctx, protocol.AssertionHash(genesisHash))
+	genesisInfo, err := chain.ReadAssertionCreationInfo(ctx, protocol.AssertionHash{Hash: genesisHash})
 	require.NoError(t, err)
 
 	t.Run("OK", func(t *testing.T) {
@@ -84,7 +84,7 @@ func TestAssertionUnrivaledBlocks(t *testing.T) {
 	}
 	genesisHash, err := chain.GenesisAssertionHash(ctx)
 	require.NoError(t, err)
-	genesisInfo, err := chain.ReadAssertionCreationInfo(ctx, protocol.AssertionHash(genesisHash))
+	genesisInfo, err := chain.ReadAssertionCreationInfo(ctx, protocol.AssertionHash{Hash: genesisHash})
 	require.NoError(t, err)
 
 	postState := &protocol.ExecutionState{
@@ -256,7 +256,7 @@ func TestAssertionBySequenceNum(t *testing.T) {
 	_, err = chain.GetAssertion(ctx, latestConfirmed.Id())
 	require.NoError(t, err)
 
-	_, err = chain.GetAssertion(ctx, protocol.AssertionHash(common.BytesToHash([]byte("foo"))))
+	_, err = chain.GetAssertion(ctx, protocol.AssertionHash{Hash: common.BytesToHash([]byte("foo"))})
 	require.ErrorIs(t, err, solimpl.ErrNotFound)
 }
 

--- a/chain-abstraction/sol-implementation/types.go
+++ b/chain-abstraction/sol-implementation/types.go
@@ -52,7 +52,7 @@ func (a *Assertion) PrevId(ctx context.Context) (protocol.AssertionHash, error) 
 	if err != nil {
 		return protocol.AssertionHash{}, err
 	}
-	return creationEvent.ParentAssertionHash, nil
+	return protocol.AssertionHash{Hash: creationEvent.ParentAssertionHash}, nil
 }
 
 func (a *Assertion) HasSecondChild() (bool, error) {
@@ -64,7 +64,9 @@ func (a *Assertion) HasSecondChild() (bool, error) {
 }
 
 func (a *Assertion) inner() (*rollupgen.AssertionNode, error) {
-	assertionNode, err := a.chain.userLogic.GetAssertion(&bind.CallOpts{}, a.id)
+	var b [32]byte
+	copy(b[:], a.id.Bytes())
+	assertionNode, err := a.chain.userLogic.GetAssertion(&bind.CallOpts{}, b)
 	if err != nil {
 		return nil, err
 	}

--- a/challenge-manager/chain-watcher/BUILD.bazel
+++ b/challenge-manager/chain-watcher/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//runtime",
         "//solgen/go/challengeV2gen",
         "@com_github_ethereum_go_ethereum//accounts/abi/bind",
+        "@com_github_ethereum_go_ethereum//common",
         "@com_github_ethereum_go_ethereum//log",
         "@com_github_ethereum_go_ethereum//metrics",
         "@com_github_pkg_errors//:errors",

--- a/challenge-manager/chain-watcher/watcher.go
+++ b/challenge-manager/chain-watcher/watcher.go
@@ -23,6 +23,7 @@ import (
 	retry "github.com/OffchainLabs/challenge-protocol-v2/runtime"
 	"github.com/OffchainLabs/challenge-protocol-v2/solgen/go/challengeV2gen"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/pkg/errors"
@@ -370,7 +371,7 @@ func (w *Watcher) processEdgeAddedEvent(
 	chal, ok := w.challenges.TryGet(assertionHash)
 	if !ok {
 		tree := challengetree.New(
-			event.OriginId,
+			protocol.AssertionHash{Hash: event.OriginId},
 			w.chain,
 			w.histChecker,
 			w.validatorName,
@@ -574,11 +575,11 @@ func (w *Watcher) processEdgeConfirmation(
 
 	// Check if we should confirm the assertion by challenge winner.
 	if edge.GetType() == protocol.BlockChallengeEdge {
-		if confirmAssertionErr := w.chain.ConfirmAssertionByChallengeWinner(ctx, protocol.AssertionHash(claimId), edgeId); confirmAssertionErr != nil {
+		if confirmAssertionErr := w.chain.ConfirmAssertionByChallengeWinner(ctx, protocol.AssertionHash{Hash: common.Hash(claimId)}, edgeId); confirmAssertionErr != nil {
 			return confirmAssertionErr
 		}
 		srvlog.Info("Assertion confirmed by challenge win", log.Ctx{
-			"assertionHash": containers.Trunc(assertionHash[:]),
+			"assertionHash": containers.Trunc(assertionHash.Bytes()),
 		})
 	}
 

--- a/challenge-manager/chain-watcher/watcher_test.go
+++ b/challenge-manager/chain-watcher/watcher_test.go
@@ -28,7 +28,7 @@ func TestWatcher_processEdgeConfirmation(t *testing.T) {
 		ctx,
 	).Return(mockChallengeManager, nil)
 
-	assertionHash := protocol.AssertionHash(common.BytesToHash([]byte("foo")))
+	assertionHash := protocol.AssertionHash{Hash: common.BytesToHash([]byte("foo"))}
 	edgeId := protocol.EdgeId(common.BytesToHash([]byte("bar")))
 	edge := &mocks.MockSpecEdge{}
 
@@ -36,7 +36,7 @@ func TestWatcher_processEdgeConfirmation(t *testing.T) {
 		"GetEdge", ctx, edgeId,
 	).Return(option.Some(protocol.SpecEdge(edge)), nil)
 
-	edge.On("ClaimId").Return(option.Some(protocol.ClaimId(assertionHash)))
+	edge.On("ClaimId").Return(option.Some(protocol.ClaimId(assertionHash.Hash)))
 	edge.On("Id").Return(edgeId)
 	edge.On("GetType").Return(protocol.BigStepChallengeEdge)
 	edge.On(
@@ -57,7 +57,7 @@ func TestWatcher_processEdgeConfirmation(t *testing.T) {
 
 	chal, ok := watcher.challenges.TryGet(assertionHash)
 	require.Equal(t, true, ok)
-	ok = chal.confirmedLevelZeroEdgeClaimIds.Has(protocol.ClaimId(assertionHash))
+	ok = chal.confirmedLevelZeroEdgeClaimIds.Has(protocol.ClaimId(assertionHash.Hash))
 	require.Equal(t, true, ok)
 }
 
@@ -70,7 +70,7 @@ func TestWatcher_processEdgeAddedEvent(t *testing.T) {
 		ctx,
 	).Return(mockChallengeManager, nil)
 
-	assertionHash := protocol.AssertionHash(common.BytesToHash([]byte("foo")))
+	assertionHash := protocol.AssertionHash{Hash: common.BytesToHash([]byte("foo"))}
 	edgeId := protocol.EdgeId(common.BytesToHash([]byte("bar")))
 	edge := &mocks.MockSpecEdge{}
 
@@ -108,7 +108,7 @@ func TestWatcher_processEdgeAddedEvent(t *testing.T) {
 
 	edge.On("Id").Return(edgeId)
 	edge.On("CreatedAtBlock").Return(uint64(0), nil)
-	edge.On("ClaimId").Return(option.Some(protocol.ClaimId(assertionHash)))
+	edge.On("ClaimId").Return(option.Some(protocol.ClaimId(assertionHash.Hash)))
 	edge.On("MutualId").Return(protocol.MutualId{})
 	edge.On("GetType").Return(protocol.BlockChallengeEdge)
 	startCommit := common.BytesToHash([]byte("nyan"))
@@ -161,7 +161,7 @@ func TestWatcher_processEdgeAddedEvent(t *testing.T) {
 	}
 	err := watcher.processEdgeAddedEvent(ctx, &challengeV2gen.EdgeChallengeManagerEdgeAdded{
 		EdgeId:   edgeId,
-		OriginId: assertionHash,
+		OriginId: assertionHash.Hash,
 	})
 	require.NoError(t, err)
 

--- a/challenge-manager/challenge-tree/tree_test.go
+++ b/challenge-manager/challenge-tree/tree_test.go
@@ -27,7 +27,7 @@ func TestAddEdge(t *testing.T) {
 		honestBigStepLevelZeroEdges:   threadsafe.NewSlice[protocol.ReadOnlyEdge](),
 		honestSmallStepLevelZeroEdges: threadsafe.NewSlice[protocol.ReadOnlyEdge](),
 	}
-	ht.topLevelAssertionHash = protocol.AssertionHash(common.BytesToHash([]byte("foo")))
+	ht.topLevelAssertionHash = protocol.AssertionHash{Hash: common.BytesToHash([]byte("foo"))}
 	ctx := context.Background()
 	edge := newEdge(&newCfg{t: t, edgeId: "blk-0.a-16.a", createdAt: 1})
 
@@ -41,7 +41,7 @@ func TestAddEdge(t *testing.T) {
 	t.Run("ignores if disagrees with top level assertion hash of edge", func(t *testing.T) {
 		ht.metadataReader = &mockMetadataReader{
 			assertionErr:  nil,
-			assertionHash: protocol.AssertionHash(common.BytesToHash([]byte("bar"))),
+			assertionHash: protocol.AssertionHash{Hash: common.BytesToHash([]byte("bar"))},
 		}
 		_, err := ht.AddEdge(ctx, edge)
 		require.NoError(t, err)

--- a/challenge-manager/challenges.go
+++ b/challenge-manager/challenges.go
@@ -54,7 +54,7 @@ func (m *Manager) ChallengeAssertion(ctx context.Context, id protocol.AssertionH
 
 	srvlog.Info("Successfully created level zero edge for block challenge", log.Ctx{
 		"name":          m.name,
-		"assertionHash": containers.Trunc(id[:]),
+		"assertionHash": containers.Trunc(id.Bytes()),
 	})
 	return nil
 }

--- a/testing/setup/rollup_stack.go
+++ b/testing/setup/rollup_stack.go
@@ -67,7 +67,7 @@ func CreateTwoValidatorFork(
 	if err != nil {
 		return nil, err
 	}
-	genesisCreationInfo, err := setup.Chains[1].ReadAssertionCreationInfo(ctx, protocol.AssertionHash(genesisHash))
+	genesisCreationInfo, err := setup.Chains[1].ReadAssertionCreationInfo(ctx, protocol.AssertionHash{Hash: genesisHash})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Instead of type aliases for `type AssertionHash common.Hash`, we could turn them into structs that embed `common.Hash` so they preserve all the methods from `common.Hash`.
