### PR TITLE
Ed ID embeds common.Hash 

### DIFF
--- a/api/edges.go
+++ b/api/edges.go
@@ -58,7 +58,7 @@ func convertSpecEdgeEdgesToEdges(ctx context.Context, e []protocol.SpecEdge) ([]
 
 func convertSpecEdgeEdgeToEdge(ctx context.Context, e protocol.SpecEdge) (*Edge, error) {
 	edge := &Edge{
-		ID:              common.Hash(e.Id()),
+		ID:              e.Id().Hash,
 		Type:            e.GetType().String(),
 		StartCommitment: toCommitment(e.StartCommitment),
 		EndCommitment:   toCommitment(e.EndCommitment),
@@ -104,7 +104,7 @@ func convertSpecEdgeEdgeToEdge(ctx context.Context, e protocol.SpecEdge) (*Edge,
 			return fmt.Errorf("failed to get edge lower child: %w", err)
 		}
 		if !lowerChild.IsNone() {
-			edge.LowerChildID = common.Hash(lowerChild.Unwrap())
+			edge.LowerChildID = lowerChild.Unwrap().Hash
 		}
 		return nil
 	})
@@ -115,7 +115,7 @@ func convertSpecEdgeEdgeToEdge(ctx context.Context, e protocol.SpecEdge) (*Edge,
 			return fmt.Errorf("failed to get edge upper child: %w", err)
 		}
 		if !upperChild.IsNone() {
-			edge.UpperChildID = common.Hash(upperChild.Unwrap())
+			edge.UpperChildID = upperChild.Unwrap().Hash
 		}
 		return nil
 	})

--- a/chain-abstraction/interfaces.go
+++ b/chain-abstraction/interfaces.go
@@ -157,7 +157,9 @@ type MutualId common.Hash
 
 // EdgeId is a unique identifier for an edge. Edge IDs encompass the edge type
 // along with the start and end height + commitment for an edge.
-type EdgeId common.Hash
+type EdgeId struct {
+	common.Hash
+}
 
 // ClaimId is the unique identifier of the commitment of a level zero edge corresponds to.
 // For example, if assertion A has two children, B and C, and a block challenge is initiated

--- a/chain-abstraction/sol-implementation/assertion_chain.go
+++ b/chain-abstraction/sol-implementation/assertion_chain.go
@@ -273,7 +273,7 @@ func (a *AssertionChain) ConfirmAssertionByChallengeWinner(
 			b,
 			creationInfo.ParentAssertionHash,
 			creationInfo.AfterState,
-			winningEdgeId,
+			winningEdgeId.Hash,
 			rollupgen.ConfigData{
 				WasmModuleRoot:      prevCreationInfo.WasmModuleRoot,
 				ConfirmPeriodBlocks: prevCreationInfo.ConfirmPeriodBlocks,

--- a/chain-abstraction/sol-implementation/edge_challenge_manager_test.go
+++ b/chain-abstraction/sol-implementation/edge_challenge_manager_test.go
@@ -255,7 +255,7 @@ func TestEdgeChallengeManager_ConfirmByOneStepProof(t *testing.T) {
 		require.NoError(t, err)
 		err = challengeManager.ConfirmEdgeByOneStepProof(
 			ctx,
-			protocol.EdgeId(common.BytesToHash([]byte("foo"))),
+			protocol.EdgeId{Hash: common.BytesToHash([]byte("foo"))},
 			&protocol.OneStepData{
 				BeforeHash:        common.Hash{},
 				Proof:             make([]byte, 0),
@@ -670,7 +670,7 @@ func TestEdgeChallengeManager_ConfirmByTimer(t *testing.T) {
 	}
 
 	t.Run("edge not found", func(t *testing.T) {
-		require.ErrorContains(t, honestEdge.ConfirmByTimer(ctx, []protocol.EdgeId{protocol.EdgeId(common.Hash{1})}), "execution reverted")
+		require.ErrorContains(t, honestEdge.ConfirmByTimer(ctx, []protocol.EdgeId{{Hash: common.Hash{1}}}), "execution reverted")
 	})
 	t.Run("confirmed by timer", func(t *testing.T) {
 		require.NoError(t, honestEdge.ConfirmByTimer(ctx, []protocol.EdgeId{}))

--- a/challenge-manager/chain-watcher/watcher.go
+++ b/challenge-manager/chain-watcher/watcher.go
@@ -355,7 +355,7 @@ func (w *Watcher) processEdgeAddedEvent(
 	if err != nil {
 		return err
 	}
-	edgeOpt, err := challengeManager.GetEdge(ctx, event.EdgeId)
+	edgeOpt, err := challengeManager.GetEdge(ctx, protocol.EdgeId{Hash: event.EdgeId})
 	if err != nil {
 		return err
 	}
@@ -419,7 +419,9 @@ func (w *Watcher) checkForEdgeConfirmedByOneStepProof(
 			)
 		}
 		_, processErr := retry.UntilSucceeds(ctx, func() (bool, error) {
-			return true, w.processEdgeConfirmation(ctx, it.Event.EdgeId)
+			return true, w.processEdgeConfirmation(ctx, protocol.EdgeId{
+				Hash: it.Event.EdgeId,
+			})
 		})
 		if processErr != nil {
 			return processErr
@@ -455,7 +457,9 @@ func (w *Watcher) checkForEdgeConfirmedByTime(
 			)
 		}
 		_, processErr := retry.UntilSucceeds(ctx, func() (bool, error) {
-			return true, w.processEdgeConfirmation(ctx, it.Event.EdgeId)
+			return true, w.processEdgeConfirmation(ctx, protocol.EdgeId{
+				Hash: it.Event.EdgeId,
+			})
 		})
 		if processErr != nil {
 			return processErr
@@ -491,7 +495,9 @@ func (w *Watcher) checkForEdgeConfirmedByChildren(
 			)
 		}
 		_, processErr := retry.UntilSucceeds(ctx, func() (bool, error) {
-			return true, w.processEdgeConfirmation(ctx, it.Event.EdgeId)
+			return true, w.processEdgeConfirmation(ctx, protocol.EdgeId{
+				Hash: it.Event.EdgeId,
+			})
 		})
 		if processErr != nil {
 			return processErr
@@ -527,7 +533,9 @@ func (w *Watcher) checkForEdgeConfirmedByClaim(
 			)
 		}
 		_, processErr := retry.UntilSucceeds(ctx, func() (bool, error) {
-			return true, w.processEdgeConfirmation(ctx, it.Event.EdgeId)
+			return true, w.processEdgeConfirmation(ctx, protocol.EdgeId{
+				Hash: it.Event.EdgeId,
+			})
 		})
 		if processErr != nil {
 			return processErr

--- a/challenge-manager/chain-watcher/watcher_test.go
+++ b/challenge-manager/chain-watcher/watcher_test.go
@@ -29,7 +29,7 @@ func TestWatcher_processEdgeConfirmation(t *testing.T) {
 	).Return(mockChallengeManager, nil)
 
 	assertionHash := protocol.AssertionHash{Hash: common.BytesToHash([]byte("foo"))}
-	edgeId := protocol.EdgeId(common.BytesToHash([]byte("bar")))
+	edgeId := protocol.EdgeId{Hash: common.BytesToHash([]byte("bar"))}
 	edge := &mocks.MockSpecEdge{}
 
 	mockChallengeManager.On(
@@ -72,7 +72,7 @@ func TestWatcher_processEdgeAddedEvent(t *testing.T) {
 
 	assertionHash := protocol.AssertionHash{Hash: common.BytesToHash([]byte("foo"))}
 	parentAssertionHash := protocol.AssertionHash{Hash: common.BytesToHash([]byte("parent foo"))}
-	edgeId := protocol.EdgeId(common.BytesToHash([]byte("bar")))
+	edgeId := protocol.EdgeId{Hash: common.BytesToHash([]byte("bar"))}
 	edge := &mocks.MockSpecEdge{}
 
 	mockChain.On(
@@ -172,7 +172,7 @@ func TestWatcher_processEdgeAddedEvent(t *testing.T) {
 		edgeManager: mockManager,
 	}
 	err := watcher.processEdgeAddedEvent(ctx, &challengeV2gen.EdgeChallengeManagerEdgeAdded{
-		EdgeId:   edgeId,
+		EdgeId:   edgeId.Hash,
 		OriginId: assertionHash.Hash,
 	})
 	require.NoError(t, err)

--- a/challenge-manager/challenge-tree/ancestors.go
+++ b/challenge-manager/challenge-tree/ancestors.go
@@ -277,7 +277,8 @@ func (ht *HonestChallengeTree) getClaimedEdge(edge protocol.ReadOnlyEdge) (proto
 		return nil, errors.New("does not claim any edge")
 	}
 	claimId := edge.ClaimId().Unwrap()
-	claimedBlockEdge, ok := ht.edges.TryGet(protocol.EdgeId(claimId))
+	claimIdHash := [32]byte(claimId)
+	claimedBlockEdge, ok := ht.edges.TryGet(protocol.EdgeId{Hash: claimIdHash})
 	if !ok {
 		return nil, errors.New("claimed edge not found")
 	}

--- a/challenge-manager/challenge-tree/ancestors_test.go
+++ b/challenge-manager/challenge-tree/ancestors_test.go
@@ -185,7 +185,7 @@ func Test_findOriginEdge(t *testing.T) {
 	origin = protocol.OriginId(common.BytesToHash([]byte("bar")))
 	got, ok := findOriginEdge(origin, edges)
 	require.Equal(t, true, ok)
-	require.Equal(t, got.Id(), protocol.EdgeId(common.BytesToHash([]byte("blk-0.a-4.a"))))
+	require.Equal(t, got.Id(), protocol.EdgeId{Hash: common.BytesToHash([]byte("blk-0.a-4.a"))})
 
 	edges.Push(newEdge(&newCfg{
 		t:         t,
@@ -198,7 +198,7 @@ func Test_findOriginEdge(t *testing.T) {
 	origin = protocol.OriginId(common.BytesToHash([]byte("baz")))
 	got, ok = findOriginEdge(origin, edges)
 	require.Equal(t, true, ok)
-	require.Equal(t, got.Id(), protocol.EdgeId(common.BytesToHash([]byte("blk-0.b-4.b"))))
+	require.Equal(t, got.Id(), protocol.EdgeId{Hash: common.BytesToHash([]byte("blk-0.b-4.b"))})
 }
 
 func buildEdges(allEdges ...*mock.Edge) map[mock.EdgeId]*mock.Edge {
@@ -329,7 +329,7 @@ func setupBlockChallengeTreeSnapshot(t *testing.T, tree *HonestChallengeTree) {
 }
 
 func id(eId mock.EdgeId) protocol.EdgeId {
-	return protocol.EdgeId(common.BytesToHash([]byte(eId)))
+	return protocol.EdgeId{Hash: common.BytesToHash([]byte(eId))}
 }
 
 // Sets up the following big step challenge snapshot:

--- a/challenge-manager/challenge-tree/mock/edge.go
+++ b/challenge-manager/challenge-tree/mock/edge.go
@@ -33,7 +33,7 @@ type Edge struct {
 }
 
 func (e *Edge) Id() protocol.EdgeId {
-	return protocol.EdgeId(common.BytesToHash([]byte(e.ID)))
+	return protocol.EdgeId{Hash: common.BytesToHash([]byte(e.ID))}
 }
 
 func (e *Edge) GetType() protocol.EdgeType {
@@ -84,7 +84,7 @@ func (e *Edge) LowerChild(_ context.Context) (option.Option[protocol.EdgeId], er
 	if e.LowerChildID == "" {
 		return option.None[protocol.EdgeId](), nil
 	}
-	return option.Some(protocol.EdgeId(common.BytesToHash([]byte(e.LowerChildID)))), nil
+	return option.Some(protocol.EdgeId{Hash: common.BytesToHash([]byte(e.LowerChildID))}), nil
 }
 
 // The upper child of the edge, if any.
@@ -92,7 +92,7 @@ func (e *Edge) UpperChild(_ context.Context) (option.Option[protocol.EdgeId], er
 	if e.UpperChildID == "" {
 		return option.None[protocol.EdgeId](), nil
 	}
-	return option.Some(protocol.EdgeId(common.BytesToHash([]byte(e.UpperChildID)))), nil
+	return option.Some(protocol.EdgeId{Hash: common.BytesToHash([]byte(e.UpperChildID))}), nil
 }
 
 func (e *Edge) HasChildren(ctx context.Context) (bool, error) {

--- a/challenge-manager/edge-tracker/tracker.go
+++ b/challenge-manager/edge-tracker/tracker.go
@@ -333,7 +333,7 @@ func (et *Tracker) uniqueTrackerLogFields() log.Ctx {
 	endHeight, endCommit := et.edge.EndCommitment()
 	id := et.edge.Id()
 	return log.Ctx{
-		"id":            containers.Trunc(id[:]),
+		"id":            id.Hash,
 		"startHeight":   startHeight,
 		"startCommit":   containers.Trunc(startCommit.Bytes()),
 		"endHeight":     endHeight,
@@ -414,10 +414,10 @@ func (et *Tracker) tryToConfirm(ctx context.Context) (bool, error) {
 	// Check if we can confirm by claim.
 	claimingEdge, ok := et.chainWatcher.ConfirmedEdgeWithClaimExists(
 		assertionHash,
-		protocol.ClaimId(et.edge.Id()),
+		protocol.ClaimId(et.edge.Id().Hash),
 	)
 	if ok {
-		if confirmClaimErr := et.edge.ConfirmByClaim(ctx, protocol.ClaimId(claimingEdge)); confirmClaimErr != nil {
+		if confirmClaimErr := et.edge.ConfirmByClaim(ctx, protocol.ClaimId(claimingEdge.Hash)); confirmClaimErr != nil {
 			return false, errors.Wrap(confirmClaimErr, "could not confirm by claim")
 		}
 		srvlog.Info("Confirmed by claim", et.uniqueTrackerLogFields())


### PR DESCRIPTION
Instead of type aliases for type `EdgeID common.Hash`, we could turn them into structs that embed common.Hash so they preserve all the methods from common.Hash.