### PR TITLE
Fix: bad osp back to start

### DIFF
--- a/challenge-manager/edge-tracker/tracker.go
+++ b/challenge-manager/edge-tracker/tracker.go
@@ -248,9 +248,6 @@ func (et *Tracker) Act(ctx context.Context) error {
 	// Edge is at a one-step-proof in a small-step challenge.
 	case edgeAtOneStepProof:
 		if err := et.submitOneStepProof(ctx); err != nil {
-			if errors.Is(err, errBadOneStepProof) {
-				return et.fsm.Do(edgeConfirm{})
-			}
 			srvlog.Error("Could not submit one step proof", err, fields)
 			return et.fsm.Do(edgeBackToStart{})
 		}


### PR DESCRIPTION
If there's a bad osp data, the tracker should go back to restart rather than try to confirm