### PR TITLE
Test Config Upgrades Mid-Challenge

### DIFF
--- a/chain-abstraction/interfaces.go
+++ b/chain-abstraction/interfaces.go
@@ -170,12 +170,8 @@ type ClaimId common.Hash
 
 // OneStepData used for confirming edges by one step proofs.
 type OneStepData struct {
-	BeforeHash             common.Hash
-	Proof                  []byte
-	WasmModuleRoot         common.Hash
-	WasmModuleRootProof    []byte
-	InboxMsgCountSeen      *big.Int
-	InboxMsgCountSeenProof []byte
+	BeforeHash common.Hash
+	Proof      []byte
 }
 
 // SpecChallengeManager implements the research specification.

--- a/chain-abstraction/sol-implementation/BUILD.bazel
+++ b/chain-abstraction/sol-implementation/BUILD.bazel
@@ -42,6 +42,7 @@ go_test(
         "//testing",
         "//testing/setup:setup_lib",
         "@com_github_ethereum_go_ethereum//:go-ethereum",
+        "@com_github_ethereum_go_ethereum//accounts/abi/bind",
         "@com_github_ethereum_go_ethereum//accounts/abi/bind/backends",
         "@com_github_ethereum_go_ethereum//common",
         "@com_github_ethereum_go_ethereum//core/types",

--- a/chain-abstraction/sol-implementation/edge_challenge_manager_test.go
+++ b/chain-abstraction/sol-implementation/edge_challenge_manager_test.go
@@ -6,15 +6,17 @@ package solimpl_test
 import (
 	"context"
 	"fmt"
-	"math/big"
 	"testing"
 
 	protocol "github.com/OffchainLabs/bold/chain-abstraction"
 	l2stateprovider "github.com/OffchainLabs/bold/layer2-state-provider"
+	"github.com/OffchainLabs/bold/solgen/go/rollupgen"
 	commitments "github.com/OffchainLabs/bold/state-commitments/history"
 	challenge_testing "github.com/OffchainLabs/bold/testing"
 	"github.com/OffchainLabs/bold/testing/setup"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 )
@@ -203,9 +205,8 @@ func TestEdgeChallengeManager_ConfirmByOneStepProof(t *testing.T) {
 			ctx,
 			protocol.EdgeId{Hash: common.BytesToHash([]byte("foo"))},
 			&protocol.OneStepData{
-				BeforeHash:        common.Hash{},
-				Proof:             make([]byte, 0),
-				InboxMsgCountSeen: big.NewInt(0),
+				BeforeHash: common.Hash{},
+				Proof:      make([]byte, 0),
 			},
 			make([]common.Hash, 0),
 			make([]common.Hash, 0),
@@ -230,17 +231,9 @@ func TestEdgeChallengeManager_ConfirmByOneStepProof(t *testing.T) {
 		parentAssertionCreationInfo, err := chain.ReadAssertionCreationInfo(ctx, id)
 		require.NoError(t, err)
 
-		cfgSnapshot := &l2stateprovider.ConfigSnapshot{
-			RequiredStake:           parentAssertionCreationInfo.RequiredStake,
-			ChallengeManagerAddress: parentAssertionCreationInfo.ChallengeManager,
-			ConfirmPeriodBlocks:     parentAssertionCreationInfo.ConfirmPeriodBlocks,
-			WasmModuleRoot:          parentAssertionCreationInfo.WasmModuleRoot,
-			InboxMaxCount:           big.NewInt(1),
-		}
-
 		data, startInclusionProof, endInclusionProof, err := honestStateManager.OneStepProofData(
 			ctx,
-			cfgSnapshot,
+			parentAssertionCreationInfo.WasmModuleRoot,
 			parentAssertionCreationInfo.AfterState,
 			fromBlockChallengeHeight,
 			fromBigStep,
@@ -369,6 +362,74 @@ func TestEdgeChallengeManager_ConfirmByTimer(t *testing.T) {
 		require.Equal(t, protocol.EdgeConfirmed, status)
 		require.NoError(t, honestEdge.ConfirmByTimer(ctx, []protocol.EdgeId{})) // already confirmed should not fail.
 	})
+}
+
+func TestUpgradingConfigMidChallenge(t *testing.T) {
+	ctx := context.Background()
+	scenario := setupOneStepProofScenario(t)
+
+	rollupAddr := scenario.topLevelFork.Addrs.Rollup
+	backend := scenario.topLevelFork.Backend
+	adminAccount := scenario.topLevelFork.Accounts[0].TxOpts
+
+	// We upgrade the Rollup's config values.
+	adminLogic, err := rollupgen.NewRollupAdminLogic(rollupAddr, backend)
+	require.NoError(t, err)
+	newWasmModuleRoot := common.BytesToHash([]byte("nyannyannyan"))
+	tx, err := adminLogic.SetWasmModuleRoot(adminAccount, newWasmModuleRoot)
+	require.NoError(t, err)
+	err = challenge_testing.WaitForTx(ctx, backend, tx)
+	require.NoError(t, err)
+	receipt, err := backend.TransactionReceipt(ctx, tx.Hash())
+	require.NoError(t, err)
+	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+
+	// We confirm the edge by one-step-proof.
+	honestEdge := scenario.smallStepHonestEdge
+	chain := scenario.topLevelFork.Chains[0]
+	challengeManager, err := scenario.topLevelFork.Chains[1].SpecChallengeManager(ctx)
+	require.NoError(t, err)
+
+	honestStateManager := scenario.honestStateManager
+	fromBlockChallengeHeight := uint64(0)
+	fromBigStep := uint64(0)
+	smallStep := uint64(0)
+
+	id, err := honestEdge.AssertionHash(ctx)
+	require.NoError(t, err)
+	parentAssertionCreationInfo, err := chain.ReadAssertionCreationInfo(ctx, id)
+	require.NoError(t, err)
+
+	// We check the config snapshot used for the one step proof is different than what
+	// is now onchain, as these values changed mid-challenge.
+	gotWasmModuleRoot, err := adminLogic.WasmModuleRoot(&bind.CallOpts{})
+	require.NoError(t, err)
+	require.Equal(t, newWasmModuleRoot[:], gotWasmModuleRoot[:])
+	require.NotEqual(t, parentAssertionCreationInfo.WasmModuleRoot[:], gotWasmModuleRoot)
+
+	data, startInclusionProof, endInclusionProof, err := honestStateManager.OneStepProofData(
+		ctx,
+		parentAssertionCreationInfo.WasmModuleRoot,
+		parentAssertionCreationInfo.AfterState,
+		fromBlockChallengeHeight,
+		fromBigStep,
+		smallStep,
+	)
+	require.NoError(t, err)
+
+	err = challengeManager.ConfirmEdgeByOneStepProof(
+		ctx,
+		honestEdge.Id(),
+		data,
+		startInclusionProof,
+		endInclusionProof,
+	)
+	require.NoError(t, err)
+
+	// Check the edge was confirmed.
+	edgeStatus, err := honestEdge.Status(ctx)
+	require.NoError(t, err)
+	require.Equal(t, protocol.EdgeConfirmed, edgeStatus)
 }
 
 // Returns a snapshot of the data for a scenario in which both honest

--- a/chain-abstraction/sol-implementation/edge_challenge_manager_test.go
+++ b/chain-abstraction/sol-implementation/edge_challenge_manager_test.go
@@ -375,12 +375,21 @@ func TestUpgradingConfigMidChallenge(t *testing.T) {
 	// We upgrade the Rollup's config values.
 	adminLogic, err := rollupgen.NewRollupAdminLogic(rollupAddr, backend)
 	require.NoError(t, err)
+
 	newWasmModuleRoot := common.BytesToHash([]byte("nyannyannyan"))
 	tx, err := adminLogic.SetWasmModuleRoot(adminAccount, newWasmModuleRoot)
 	require.NoError(t, err)
 	err = challenge_testing.WaitForTx(ctx, backend, tx)
 	require.NoError(t, err)
 	receipt, err := backend.TransactionReceipt(ctx, tx.Hash())
+	require.NoError(t, err)
+	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+
+	tx, err = adminLogic.SetConfirmPeriodBlocks(adminAccount, uint64(329094))
+	require.NoError(t, err)
+	err = challenge_testing.WaitForTx(ctx, backend, tx)
+	require.NoError(t, err)
+	receipt, err = backend.TransactionReceipt(ctx, tx.Hash())
 	require.NoError(t, err)
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 

--- a/challenge-manager/edge-tracker/tracker.go
+++ b/challenge-manager/edge-tracker/tracker.go
@@ -676,16 +676,9 @@ func (et *Tracker) submitOneStepProof(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	cfgSnapshot := &l2stateprovider.ConfigSnapshot{
-		RequiredStake:           parentAssertionCreationInfo.RequiredStake,
-		ChallengeManagerAddress: parentAssertionCreationInfo.ChallengeManager,
-		ConfirmPeriodBlocks:     parentAssertionCreationInfo.ConfirmPeriodBlocks,
-		WasmModuleRoot:          parentAssertionCreationInfo.WasmModuleRoot,
-		InboxMaxCount:           parentAssertionCreationInfo.InboxMaxCount,
-	}
 	data, beforeStateInclusionProof, afterStateInclusionProof, err := et.stateProvider.OneStepProofData(
 		ctx,
-		cfgSnapshot,
+		parentAssertionCreationInfo.WasmModuleRoot,
 		parentAssertionCreationInfo.AfterState,
 		fromAssertionHeight,
 		fromBigStep,

--- a/layer2-state-provider/provider.go
+++ b/layer2-state-provider/provider.go
@@ -130,7 +130,7 @@ type PrefixProver interface {
 type OneStepProofProvider interface {
 	OneStepProofData(
 		ctx context.Context,
-		cfgSnapshot *ConfigSnapshot,
+		wasmModuleRoot common.Hash,
 		postState rollupgen.ExecutionState,
 		messageNumber,
 		bigStep,

--- a/testing/mocks/mocks.go
+++ b/testing/mocks/mocks.go
@@ -167,13 +167,13 @@ func (m *MockStateManager) SmallStepCommitmentUpTo(
 
 func (m *MockStateManager) OneStepProofData(
 	ctx context.Context,
-	cfgSnapshot *l2stateprovider.ConfigSnapshot,
+	wasmModuleRoot common.Hash,
 	postState rollupgen.ExecutionState,
 	blockHeight,
 	bigStep,
 	smallStep uint64,
 ) (data *protocol.OneStepData, startLeafInclusionProof, endLeafInclusionProof []common.Hash, err error) {
-	args := m.Called(ctx, cfgSnapshot, postState, blockHeight, bigStep, smallStep)
+	args := m.Called(ctx, wasmModuleRoot, postState, blockHeight, bigStep, smallStep)
 	return args.Get(0).(*protocol.OneStepData), args.Get(1).([]common.Hash), args.Get(2).([]common.Hash), args.Error(3)
 }
 


### PR DESCRIPTION
This PR adds a test that updates config values in the rollup admin in the middle of a challenge and ensures one step proofs can still be successful