### PR TITLE
fix: only 1 edge can be confirmed per mutual id

### DIFF
--- a/contracts/src/challengeV2/libraries/ChallengeEdgeLib.sol
+++ b/contracts/src/challengeV2/libraries/ChallengeEdgeLib.sol
@@ -170,7 +170,7 @@ library ChallengeEdgeLib {
         return mutualIdComponent(ce.eType, ce.originId, ce.startHeight, ce.startHistoryRoot, ce.endHeight);
     }
 
-    function mutualIdMemory(ChallengeEdge memory ce) internal pure returns (bytes32) {
+    function mutualIdMem(ChallengeEdge memory ce) internal pure returns (bytes32) {
         return mutualIdComponent(ce.eType, ce.originId, ce.startHeight, ce.startHistoryRoot, ce.endHeight);
     }
 

--- a/contracts/src/challengeV2/libraries/ChallengeEdgeLib.sol
+++ b/contracts/src/challengeV2/libraries/ChallengeEdgeLib.sol
@@ -170,6 +170,10 @@ library ChallengeEdgeLib {
         return mutualIdComponent(ce.eType, ce.originId, ce.startHeight, ce.startHistoryRoot, ce.endHeight);
     }
 
+    function mutualIdMemory(ChallengeEdge memory ce) internal pure returns (bytes32) {
+        return mutualIdComponent(ce.eType, ce.originId, ce.startHeight, ce.startHistoryRoot, ce.endHeight);
+    }
+
     /// @notice The id of an edge. Edges are uniquely identified by their id, and commit to the same information
     function idComponent(
         uint256 eType,

--- a/contracts/src/challengeV2/libraries/ChallengeErrors.sol
+++ b/contracts/src/challengeV2/libraries/ChallengeErrors.sol
@@ -90,3 +90,5 @@ error EmptyOneStepProofEntry();
 error EmptyChallengePeriod();
 /// @dev No stake receiver address supplied
 error EmptyStakeReceiver();
+/// @dev A rival edge is already confirmed
+error RivalEdgeConfirmed(bytes32 edgeId, bytes32 confirmedRivalId);

--- a/contracts/test/challengeV2/EdgeChallengeManager.t.sol
+++ b/contracts/test/challengeV2/EdgeChallengeManager.t.sol
@@ -395,8 +395,8 @@ contract EdgeChallengeManagerTest is Test {
         assertFalse(ei.challengeManager.getEdge(edge1Id).status == ei.challengeManager.getEdge(edge2Id).status);
         assertTrue(edge1Id != edge2Id, "Same edge");
         assertEq(
-            ei.challengeManager.getEdge(edge1Id).mutualIdMemory(),
-            ei.challengeManager.getEdge(edge2Id).mutualIdMemory(),
+            ei.challengeManager.getEdge(edge1Id).mutualIdMem(),
+            ei.challengeManager.getEdge(edge2Id).mutualIdMem(),
             "Is rival"
         );
     }

--- a/contracts/test/challengeV2/EdgeChallengeManager.t.sol
+++ b/contracts/test/challengeV2/EdgeChallengeManager.t.sol
@@ -1072,7 +1072,7 @@ contract EdgeChallengeManagerTest is Test {
 
         vm.roll(block.number + 1);
 
-        // assertEq(args.challengeManager.timeUnrivaled(edge1Id), 1, "Edge1 timer");
+        assertEq(args.challengeManager.timeUnrivaled(edge1Id), 1, "Edge1 timer");
 
         (bytes32[] memory states2, bytes32[] memory exp2) =
             appendRandomStatesBetween(genesisStates(), StateToolsLib.mockMachineHash(args.endState2), height1);

--- a/contracts/test/challengeV2/EdgeChallengeManager.t.sol
+++ b/contracts/test/challengeV2/EdgeChallengeManager.t.sol
@@ -394,7 +394,11 @@ contract EdgeChallengeManagerTest is Test {
         ei.challengeManager.confirmEdgeByChildren(edge2Id);
         assertFalse(ei.challengeManager.getEdge(edge1Id).status == ei.challengeManager.getEdge(edge2Id).status);
         assertTrue(edge1Id != edge2Id, "Same edge");
-        assertEq(ei.challengeManager.getEdge(edge1Id).mutualIdMemory(), ei.challengeManager.getEdge(edge2Id).mutualIdMemory(), "Is rival");
+        assertEq(
+            ei.challengeManager.getEdge(edge1Id).mutualIdMemory(),
+            ei.challengeManager.getEdge(edge2Id).mutualIdMemory(),
+            "Is rival"
+        );
     }
 
     function bisect(

--- a/contracts/test/challengeV2/EdgeChallengeManagerLib.t.sol
+++ b/contracts/test/challengeV2/EdgeChallengeManagerLib.t.sol
@@ -883,7 +883,7 @@ contract EdgeChallengeManagerLibTest is Test {
         store.edges[upperChildId].setConfirmed();
 
         store.confirmEdgeByChildren(parentEdgeId);
-        vm.expectRevert(abi.encodeWithSelector(EdgeNotPending.selector, parentEdgeId, EdgeStatus.Confirmed));
+        vm.expectRevert(abi.encodeWithSelector(RivalEdgeConfirmed.selector, parentEdgeId, parentEdgeId));
         store.confirmEdgeByChildren(parentEdgeId);
     }
 


### PR DESCRIPTION
To reproduce the issue, on b4394ba10fb6b1432b2e0de7bbe106edbbd2915d run
```
forge test --match-test testRevertConfirmAnotherRival
```

This PR fixes the issue by adding `rivalConfirmed` mapping to track if any rival with the same mutual id is confirmed, and prevent edge from confirming if there is one confirmed already. 