### PR TITLE
Removed  block check from setrefunded

### DIFF
--- a/contracts/src/challengeV2/libraries/ChallengeEdgeLib.sol
+++ b/contracts/src/challengeV2/libraries/ChallengeEdgeLib.sol
@@ -244,7 +244,7 @@ library ChallengeEdgeLib {
     }
 
     /// @notice Set the refunded flag of an edge
-    /// @dev    Checks internally that edge is confirmed, Block type, layer zero edge and hasnt been refunded already
+    /// @dev    Checks internally that edge is confirmed, layer zero edge and hasnt been refunded already
     function setRefunded(ChallengeEdge storage edge) internal {
         if (edge.status != EdgeStatus.Confirmed) {
             revert EdgeNotConfirmed(ChallengeEdgeLib.id(edge), edge.status);

--- a/contracts/src/challengeV2/libraries/ChallengeEdgeLib.sol
+++ b/contracts/src/challengeV2/libraries/ChallengeEdgeLib.sol
@@ -249,9 +249,6 @@ library ChallengeEdgeLib {
         if (edge.status != EdgeStatus.Confirmed) {
             revert EdgeNotConfirmed(ChallengeEdgeLib.id(edge), edge.status);
         }
-        if (edge.eType != EdgeType.Block) {
-            revert EdgeTypeNotBlock(edge.eType);
-        }
         if (!isLayerZero(edge)) {
             revert EdgeNotLayerZero(ChallengeEdgeLib.id(edge), edge.staker, edge.claimId);
         }

--- a/contracts/test/challengeV2/EdgeChallengeManager.t.sol
+++ b/contracts/test/challengeV2/EdgeChallengeManager.t.sol
@@ -1397,14 +1397,24 @@ contract EdgeChallengeManagerTest is Test {
 
     function testRevertRefundStakeBigStep() external {
         (EdgeInitData memory ei, BisectionChildren[] memory allWinners) = testCanConfirmByOneStep();
-        vm.expectRevert(abi.encodeWithSelector(EdgeTypeNotBlock.selector, EdgeType.BigStep));
+
+        IERC20 stakeToken = ei.challengeManager.stakeToken();
+        uint256 beforeBalance = stakeToken.balanceOf(address(this));
+        vm.prank(nobody); // call refund as nobody
         ei.challengeManager.refundStake(allWinners[11].lowerChildId);
+        uint256 afterBalance = stakeToken.balanceOf(address(this));
+        assertEq(afterBalance - beforeBalance, ei.challengeManager.stakeAmount(), "Stake refunded");
     }
 
     function testRevertRefundStakeSmallStep() external {
         (EdgeInitData memory ei, BisectionChildren[] memory allWinners) = testCanConfirmByOneStep();
-        vm.expectRevert(abi.encodeWithSelector(EdgeTypeNotBlock.selector, EdgeType.SmallStep));
+
+        IERC20 stakeToken = ei.challengeManager.stakeToken();
+        uint256 beforeBalance = stakeToken.balanceOf(address(this));
+        vm.prank(nobody); // call refund as nobody
         ei.challengeManager.refundStake(allWinners[5].lowerChildId);
+        uint256 afterBalance = stakeToken.balanceOf(address(this));
+        assertEq(afterBalance - beforeBalance, ei.challengeManager.stakeAmount(), "Stake refunded");
     }
 
     function testRevertRefundStakeNotConfirmed() external {

--- a/contracts/test/challengeV2/EdgeChallengeManager.t.sol
+++ b/contracts/test/challengeV2/EdgeChallengeManager.t.sol
@@ -1395,7 +1395,7 @@ contract EdgeChallengeManagerTest is Test {
         ei.challengeManager.refundStake(allWinners[16].lowerChildId);
     }
 
-    function testRevertRefundStakeBigStep() external {
+    function testRefundStakeBigStep() external {
         (EdgeInitData memory ei, BisectionChildren[] memory allWinners) = testCanConfirmByOneStep();
 
         IERC20 stakeToken = ei.challengeManager.stakeToken();
@@ -1406,7 +1406,7 @@ contract EdgeChallengeManagerTest is Test {
         assertEq(afterBalance - beforeBalance, ei.challengeManager.stakeAmount(), "Stake refunded");
     }
 
-    function testRevertRefundStakeSmallStep() external {
+    function testRefundStakeSmallStep() external {
         (EdgeInitData memory ei, BisectionChildren[] memory allWinners) = testCanConfirmByOneStep();
 
         IERC20 stakeToken = ei.challengeManager.stakeToken();


### PR DESCRIPTION
All zero layer edges can contain stake - so we need to allow refunding on all of them