### PR TITLE
Fix: do nothing if ancestor already confirmed

### DIFF
--- a/challenge-manager/chain-watcher/watcher_test.go
+++ b/challenge-manager/chain-watcher/watcher_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var _ ConfirmationMetadataChecker = (*Watcher)(nil)
+
 func TestWatcher_processEdgeConfirmation(t *testing.T) {
 	ctx := context.Background()
 	mockChain := &mocks.MockProtocol{}

--- a/challenge-manager/manager.go
+++ b/challenge-manager/manager.go
@@ -222,27 +222,6 @@ func (m *Manager) MarkTrackedEdge(edgeId protocol.EdgeId) {
 	m.trackedEdgeIds.Insert(edgeId)
 }
 
-// GetAncestorEdge returns the ancestor edge of  a given edge id.
-func (m *Manager) GetAncestorEdge(ctx context.Context, edgeId protocol.EdgeId) (protocol.SpecEdge, error) {
-	for _, edge := range m.watcher.GetEdges() {
-		lowerChild, err := edge.LowerChild(ctx)
-		if err != nil {
-			return nil, err
-		}
-		if lowerChild.Unwrap() == edgeId {
-			return edge, nil
-		}
-		upperChild, err := edge.UpperChild(ctx)
-		if err != nil {
-			return nil, err
-		}
-		if upperChild.Unwrap() == edgeId {
-			return edge, nil
-		}
-	}
-	return nil, nil
-}
-
 // Mode returns the mode of the challenge manager.
 func (m *Manager) Mode() types.Mode {
 	return m.mode

--- a/challenge-manager/manager.go
+++ b/challenge-manager/manager.go
@@ -222,6 +222,27 @@ func (m *Manager) MarkTrackedEdge(edgeId protocol.EdgeId) {
 	m.trackedEdgeIds.Insert(edgeId)
 }
 
+// GetAncestorEdge returns the ancestor edge of  a given edge id.
+func (m *Manager) GetAncestorEdge(ctx context.Context, edgeId protocol.EdgeId) (protocol.SpecEdge, error) {
+	for _, edge := range m.watcher.GetEdges() {
+		lowerChild, err := edge.LowerChild(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if lowerChild.Unwrap() == edgeId {
+			return edge, nil
+		}
+		upperChild, err := edge.UpperChild(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if upperChild.Unwrap() == edgeId {
+			return edge, nil
+		}
+	}
+	return nil, nil
+}
+
 // Mode returns the mode of the challenge manager.
 func (m *Manager) Mode() types.Mode {
 	return m.mode


### PR DESCRIPTION
This PR implements a helper to get the ancestor edge inputting child edge. And returns early in the tracker routine if the ancestor edge has been confirmed. Returns early from the following functions
- Bisect
- Confirm
- Subchallenge leaf