### PR TITLE
ToB fixes

### DIFF
--- a/contracts/src/challengeV2/libraries/ChallengeErrors.sol
+++ b/contracts/src/challengeV2/libraries/ChallengeErrors.sol
@@ -37,9 +37,9 @@ error InvalidEndHeight(uint256 actualHeight, uint256 expectedHeight);
 /// @dev The prefix proof is empty
 error EmptyPrefixProof();
 /// @dev The edge is not of type Block
-error EdgeTypeNotBlock(uint256 eType);
+error EdgeTypeNotBlock(uint256 level);
 /// @dev The edge is not of type SmallStep
-error EdgeTypeNotSmallStep(uint256 eType);
+error EdgeTypeNotSmallStep(uint256 level);
 /// @dev The first rival record is empty
 error EmptyFirstRival();
 /// @dev The difference between two heights is less than 2

--- a/contracts/src/rollup/BOLDUpgradeAction.sol
+++ b/contracts/src/rollup/BOLDUpgradeAction.sol
@@ -325,7 +325,7 @@ contract BOLDUpgradeAction {
         (ExecutionState memory genesisExecState, uint256 inboxMaxCount) = PREIMAGE_LOOKUP.get(latestConfirmedStateHash);
         // double check the hash
         require(
-            RollupLib.stateHashMem(genesisExecState, inboxMaxCount) == latestConfirmedStateHash,
+            PREIMAGE_LOOKUP.stateHash(genesisExecState, inboxMaxCount) == latestConfirmedStateHash,
             "Invalid latest execution hash"
         );
 
@@ -354,7 +354,7 @@ contract BOLDUpgradeAction {
     }
 
     function upgradeSurroundingContracts(address newRollupAddress) private {
-        // upgrade each of these contracts to an implementation that allows 
+        // upgrade each of these contracts to an implementation that allows
         // the rollup address to be set to the new rollup address
 
         TransparentUpgradeableProxy bridge = TransparentUpgradeableProxy(payable(BRIDGE));

--- a/contracts/src/rollup/BOLDUpgradeAction.sol
+++ b/contracts/src/rollup/BOLDUpgradeAction.sol
@@ -354,9 +354,8 @@ contract BOLDUpgradeAction {
     }
 
     function upgradeSurroundingContracts(address newRollupAddress) private {
-        // now we upgrade each of the contracts that a reference to the rollup address
-        // first we upgrade to an implementation which allows setting, then set the rollup address
-        // then we revert to the previous implementation since we dont require this functionality going forward
+        // upgrade each of these contracts to an implementation that allows 
+        // the rollup address to be set to the new rollup address
 
         TransparentUpgradeableProxy bridge = TransparentUpgradeableProxy(payable(BRIDGE));
         address currentBridgeImpl = PROXY_ADMIN_BRIDGE.getProxyImplementation(bridge);

--- a/contracts/src/rollup/RollupCore.sol
+++ b/contracts/src/rollup/RollupCore.sol
@@ -453,6 +453,8 @@ abstract contract RollupCore is IRollupCore, PausableUpgradeable {
             } else {
                 nextInboxPosition = currentInboxPosition;
             }
+            // sanity check that the next inbox position did indeed move forward due to the code above
+            require(assertion.beforeStateData.configData.nextInboxPosition > prevInboxPosition, "NEXT_INBOX_BACKWARDS");
 
             // only the genesis assertion processes no messages, and that assertion is created
             // when we initialize this contract. Therefore, all assertions created here should have a non

--- a/contracts/src/rollup/RollupCore.sol
+++ b/contracts/src/rollup/RollupCore.sol
@@ -408,9 +408,9 @@ abstract contract RollupCore is IRollupCore, PausableUpgradeable {
             //    All types of assertion must have inbox position in the range prev.inboxPosition <= x <= prev.nextInboxPosition
             require(afterInboxPosition >= prevInboxPosition, "INBOX_BACKWARDS");
             require(afterInboxPosition <= assertion.beforeStateData.configData.nextInboxPosition, "INBOX_TOO_FAR");
-            
+
             // SANITY CHECK: the next inbox position did indeed move forward
-            // this is enforced by code in a later section that artificially increases the nextInboxPosition 
+            // this is enforced by code in a later section that artificially increases the nextInboxPosition
             // if it hadn't changed the next inbox always increasing means that the assertions will continue to advance
             // It also means that below, where we check that afterInboxPosition equals prev.nextInboxPosition
             // in the FINISHED state, we can be sure that it processed at least one message

--- a/contracts/src/rollup/RollupCreator.sol
+++ b/contracts/src/rollup/RollupCreator.sol
@@ -117,7 +117,8 @@ contract RollupCreator is Ownable {
         deployed.proxyAdmin.transferOwnership(config.owner);
 
         // Create the rollup proxy to figure out the address and initialize it later
-        deployed.rollup = new RollupProxy{salt: keccak256(abi.encode(config))}();
+        deployed.rollup =
+        new RollupProxy{salt: keccak256(abi.encode(config, _batchPoster, _validators, disableValidatorWhitelist, maxDataSize))}();
 
         (deployed.bridge, deployed.sequencerInbox, deployed.inbox, deployed.rollupEventInbox, deployed.outbox) =
         bridgeCreator.createBridge(

--- a/contracts/src/rollup/RollupLib.sol
+++ b/contracts/src/rollup/RollupLib.sol
@@ -18,37 +18,6 @@ import "../challengeV2/EdgeChallengeManager.sol";
 library RollupLib {
     using GlobalStateLib for GlobalState;
 
-    function stateHash(ExecutionState calldata execState, uint256 inboxMaxCount)
-        internal
-        pure
-        returns (bytes32)
-    {
-        return
-            keccak256(
-                abi.encodePacked(
-                    execState.globalState.hash(),
-                    inboxMaxCount,
-                    execState.machineStatus
-                )
-            );
-    }
-
-    /// @dev same as stateHash but expects execState in memory instead of calldata
-    function stateHashMem(ExecutionState memory execState, uint256 inboxMaxCount)
-        internal
-        pure
-        returns (bytes32)
-    {
-        return
-            keccak256(
-                abi.encodePacked(
-                    execState.globalState.hash(),
-                    inboxMaxCount,
-                    execState.machineStatus
-                )
-            );
-    }
-
     // Not the same as a machine hash for a given execution state
     function executionStateHash(ExecutionState memory state) internal pure returns (bytes32) {
         return keccak256(abi.encodePacked(state.machineStatus, state.globalState.hash()));

--- a/contracts/test/Rollup.t.sol
+++ b/contracts/test/Rollup.t.sol
@@ -23,6 +23,7 @@ import "../src/libraries/Error.sol";
 import "../src/mocks/TestWETH9.sol";
 import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import "@openzeppelin/contracts-upgradeable/utils/Create2Upgradeable.sol";
 
 contract RollupTest is Test {
     address constant owner = address(1337);
@@ -127,6 +128,11 @@ contract RollupTest is Test {
         vm.expectEmit(false, false, false, false);
         emit RollupCreated(address(0), address(0), address(0), address(0), address(0));
         address rollupAddr = rollupCreator.createRollup(config, address(0), new address[](0), false, MAX_DATA_SIZE);
+        bytes32 rollupSalt = keccak256(abi.encode(config, address(0), new address[](0), false, MAX_DATA_SIZE));
+        address expectedRollupAddress = Create2Upgradeable.computeAddress(
+            rollupSalt, keccak256(type(RollupProxy).creationCode), address(rollupCreator)
+        );
+        assertEq(expectedRollupAddress, rollupAddr, "Unexpected rollup address");
 
         userRollup = RollupUserLogic(address(rollupAddr));
         adminRollup = RollupAdminLogic(address(rollupAddr));

--- a/contracts/test/Rollup.t.sol
+++ b/contracts/test/Rollup.t.sol
@@ -126,9 +126,7 @@ contract RollupTest is Test {
 
         vm.expectEmit(false, false, false, false);
         emit RollupCreated(address(0), address(0), address(0), address(0), address(0));
-        address rollupAddr = rollupCreator.createRollup(
-            config, address(0), new address[](0), false, MAX_DATA_SIZE
-        );
+        address rollupAddr = rollupCreator.createRollup(config, address(0), new address[](0), false, MAX_DATA_SIZE);
 
         userRollup = RollupUserLogic(address(rollupAddr));
         adminRollup = RollupAdminLogic(address(rollupAddr));

--- a/contracts/test/challengeV2/EdgeChallengeManagerLib.t.sol
+++ b/contracts/test/challengeV2/EdgeChallengeManagerLib.t.sol
@@ -1582,21 +1582,16 @@ contract EdgeChallengeManagerLibTest is Test {
     struct ExecStateVars {
         ExecutionState execState;
         bytes32 machineHash;
-        bytes32 stateHash;
     }
 
-    function randomExecutionState(IOneStepProofEntry os, uint256 inboxMaxCount)
-        private
-        returns (ExecStateVars memory)
-    {
+    function randomExecutionState(IOneStepProofEntry os) private returns (ExecStateVars memory) {
         ExecutionState memory execState = ExecutionState(
             GlobalState([rand.hash(), rand.hash()], [uint64(uint256(rand.hash())), uint64(uint256(rand.hash()))]),
             MachineStatus.FINISHED
         );
 
         bytes32 machineHash = os.getMachineHash(execState);
-        bytes32 stateHash = RollupLib.stateHashMem(execState, inboxMaxCount);
-        return ExecStateVars(execState, machineHash, stateHash);
+        return ExecStateVars(execState, machineHash);
     }
 
     function createZeroBlockEdge(uint256 mode) internal {
@@ -1608,8 +1603,8 @@ contract EdgeChallengeManagerLibTest is Test {
             revertArg = abi.encodeWithSelector(NotPowerOfTwo.selector, expectedEndHeight);
         }
 
-        ExecStateVars memory startExec = randomExecutionState(entry, 10);
-        ExecStateVars memory endExec = randomExecutionState(entry, 20);
+        ExecStateVars memory startExec = randomExecutionState(entry);
+        ExecStateVars memory endExec = randomExecutionState(entry);
         ExpsAndProofs memory roots = newRootsAndProofs(0, expectedEndHeight, startExec.machineHash, endExec.machineHash);
         bytes32 claimId = rand.hash();
         bytes32 endRoot;


### PR DESCRIPTION
Misc fixes related to tob audit
* Rename etype to level in some errors
* Removed unused state hashes
* Added additional sanity check to create assertion
* Added additional params to rollup creator salt
* Updated upgradeSurroundingContracts comments
* Additional tests for hash types and createlayerzeroedge conditions