### PR TITLE
Cleanup Logic to Support Many Subchallenge Levels

### DIFF
--- a/assertions/scanner_test.go
+++ b/assertions/scanner_test.go
@@ -39,7 +39,8 @@ func TestScanner_ProcessAssertionCreation(t *testing.T) {
 		}
 
 		p := &mocks.MockProtocol{}
-		p.On("SpecChallengeManager", ctx).Return(&mocks.MockSpecChallengeManager{}, nil)
+		cm := &mocks.MockSpecChallengeManager{}
+		p.On("SpecChallengeManager", ctx).Return(cm, nil)
 		p.On("ReadAssertionCreationInfo", ctx, mockId(2)).Return(&protocol.AssertionCreatedInfo{
 			ParentAssertionHash: mockId(1).Hash,
 			AfterState:          rollupgen.ExecutionState{},
@@ -150,8 +151,10 @@ func setupChallengeManager(t *testing.T) (*challengemanager.Manager, *mocks.Mock
 	t.Helper()
 	p := &mocks.MockProtocol{}
 	ctx := context.Background()
-	p.On("CurrentChallengeManager", ctx).Return(&mocks.MockChallengeManager{}, nil)
-	p.On("SpecChallengeManager", ctx).Return(&mocks.MockSpecChallengeManager{}, nil)
+	cm := &mocks.MockSpecChallengeManager{}
+	cm.On("NumBigSteps", ctx).Return(uint8(1), nil)
+	p.On("CurrentChallengeManager", ctx).Return(cm, nil)
+	p.On("SpecChallengeManager", ctx).Return(cm, nil)
 	s := &mocks.MockStateManager{}
 	cfg, err := setup.ChainsWithEdgeChallengeManager()
 	require.NoError(t, err)

--- a/chain-abstraction/interfaces.go
+++ b/chain-abstraction/interfaces.go
@@ -17,6 +17,13 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
+// LayerZeroHeights for edges configured as parameters in the challenge manager contract.
+type LayerZeroHeights struct {
+	BlockChallengeHeight     uint64
+	BigStepChallengeHeight   uint64
+	SmallStepChallengeHeight uint64
+}
+
 // AssertionHash represents a unique identifier for an assertion
 // constructed as a keccak256 hash of some of its internals.
 type AssertionHash struct {
@@ -189,8 +196,10 @@ type OneStepData struct {
 type SpecChallengeManager interface {
 	// Address of the challenge manager contract.
 	Address() common.Address
-	// Heights for level zero edge creation.
-	LevelZeroBlockEdgeHeight(ctx context.Context) (uint64, error)
+	// Layer zero edge heights defined the challenge manager contract.
+	LayerZeroHeights(ctx context.Context) (*LayerZeroHeights, error)
+	// Number of big step challenge levels defined in the challenge manager contract.
+	NumBigSteps(ctx context.Context) (uint8, error)
 	// Duration of the challenge period in blocks.
 	ChallengePeriodBlocks(ctx context.Context) (uint64, error)
 	// Gets an edge by its id.

--- a/chain-abstraction/sol-implementation/edge_challenge_manager.go
+++ b/chain-abstraction/sol-implementation/edge_challenge_manager.go
@@ -444,7 +444,7 @@ func (cm *specChallengeManager) NumBigSteps(ctx context.Context) (uint8, error) 
 		return 0, err
 	}
 	if !n.IsUint64() {
-		return 0, errors.New("layer zero block edge height was not a uint64")
+		return 0, errors.New("num big step levels was not a uint64")
 	}
 	if n.Uint64() > 255 {
 		return 0, errors.New("number of big steps was greater than 255")

--- a/chain-abstraction/sol-implementation/edge_challenge_manager.go
+++ b/chain-abstraction/sol-implementation/edge_challenge_manager.go
@@ -409,6 +409,49 @@ func (cm *specChallengeManager) Address() common.Address {
 	return cm.addr
 }
 
+func (cm *specChallengeManager) LayerZeroHeights(ctx context.Context) (*protocol.LayerZeroHeights, error) {
+	h, err := cm.caller.LAYERZEROBLOCKEDGEHEIGHT(&bind.CallOpts{Context: ctx})
+	if err != nil {
+		return nil, err
+	}
+	if !h.IsUint64() {
+		return nil, errors.New("layer zero block edge height was not a uint64")
+	}
+	bs, err := cm.caller.LAYERZEROBIGSTEPEDGEHEIGHT(&bind.CallOpts{Context: ctx})
+	if err != nil {
+		return nil, err
+	}
+	if !bs.IsUint64() {
+		return nil, errors.New("layer zero big step edge height was not a uint64")
+	}
+	ss, err := cm.caller.LAYERZEROSMALLSTEPEDGEHEIGHT(&bind.CallOpts{Context: ctx})
+	if err != nil {
+		return nil, err
+	}
+	if !ss.IsUint64() {
+		return nil, errors.New("layer zero small step height was not a uint64")
+	}
+	return &protocol.LayerZeroHeights{
+		BlockChallengeHeight:     h.Uint64(),
+		BigStepChallengeHeight:   bs.Uint64(),
+		SmallStepChallengeHeight: ss.Uint64(),
+	}, nil
+}
+
+func (cm *specChallengeManager) NumBigSteps(ctx context.Context) (uint8, error) {
+	n, err := cm.caller.NUMBIGSTEPLEVEL(&bind.CallOpts{Context: ctx})
+	if err != nil {
+		return 0, err
+	}
+	if !n.IsUint64() {
+		return 0, errors.New("layer zero block edge height was not a uint64")
+	}
+	if n.Uint64() > 255 {
+		return 0, errors.New("number of big steps was greater than 255")
+	}
+	return uint8(n.Uint64()), nil
+}
+
 func (cm *specChallengeManager) LevelZeroBlockEdgeHeight(ctx context.Context) (uint64, error) {
 	h, err := cm.caller.LAYERZEROBLOCKEDGEHEIGHT(&bind.CallOpts{Context: ctx})
 	if err != nil {

--- a/challenge-manager/BUILD.bazel
+++ b/challenge-manager/BUILD.bazel
@@ -40,9 +40,11 @@ go_test(
         "//challenge-manager/chain-watcher",
         "//challenge-manager/edge-tracker",
         "//challenge-manager/types",
+        "//solgen/go/challengeV2gen",
         "//testing/mocks",
         "//testing/setup:setup_lib",
         "//time",
+        "@com_github_ethereum_go_ethereum//accounts/abi/bind",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/challenge-manager/chain-watcher/watcher.go
+++ b/challenge-manager/chain-watcher/watcher.go
@@ -89,6 +89,7 @@ type Watcher struct {
 	challenges           *threadsafe.Map[protocol.AssertionHash, *trackedChallenge]
 	backend              bind.ContractBackend
 	validatorName        string
+	numBigStepLevels     uint8
 	initialSyncCompleted atomic.Bool
 }
 
@@ -100,6 +101,7 @@ func New(
 	histChecker l2stateprovider.HistoryChecker,
 	backend bind.ContractBackend,
 	interval time.Duration,
+	numBigStepLevels uint8,
 	validatorName string,
 ) *Watcher {
 	return &Watcher{
@@ -109,6 +111,7 @@ func New(
 		challenges:         threadsafe.NewMap[protocol.AssertionHash, *trackedChallenge](),
 		backend:            backend,
 		histChecker:        histChecker,
+		numBigStepLevels:   numBigStepLevels,
 		validatorName:      validatorName,
 	}
 }
@@ -335,6 +338,7 @@ func (w *Watcher) AddVerifiedHonestEdge(ctx context.Context, edge protocol.Verif
 			assertionHash,
 			w.chain,
 			w.histChecker,
+			w.numBigStepLevels,
 			w.validatorName,
 		)
 		chal = &trackedChallenge{
@@ -414,6 +418,7 @@ func (w *Watcher) processEdgeAddedEvent(
 			protocol.AssertionHash{Hash: event.OriginId},
 			w.chain,
 			w.histChecker,
+			w.numBigStepLevels,
 			w.validatorName,
 		)
 		chal = &trackedChallenge{

--- a/challenge-manager/challenge-tree/generalized_path_timer.go
+++ b/challenge-manager/challenge-tree/generalized_path_timer.go
@@ -334,7 +334,3 @@ func findOriginEdge(originId protocol.OriginId, edges *threadsafe.Slice[protocol
 func errNotFound(id protocol.EdgeId) error {
 	return errors.Wrapf(ErrNotFound, "id=%#x", id)
 }
-
-func errNoLevelZero(originId protocol.OriginId) error {
-	return errors.Wrapf(ErrNoLevelZero, "originId=%#x", originId)
-}

--- a/challenge-manager/challenge-tree/generalized_path_timer.go
+++ b/challenge-manager/challenge-tree/generalized_path_timer.go
@@ -132,10 +132,10 @@ func (ht *HonestChallengeTree) ComputeAncestorsWithTimers(
 	edgeId protocol.EdgeId,
 	blockNumber uint64,
 ) (*AncestorsQueryResponse, error) {
-	// Checks if we have a block challenge root edge.
-	if ht.honestBlockChalLevelZeroEdge.IsNone() {
-		return nil, ErrNoHonestTopLevelEdge
-	}
+	// // Checks if we have a block challenge root edge.
+	// if ht.honestBlockChalLevelZeroEdge.IsNone() {
+	// 	return nil, ErrNoHonestTopLevelEdge
+	// }
 	// Checks if the edge exists before performing any computation.
 	startEdge, ok := ht.edges.TryGet(edgeId)
 	if !ok {
@@ -211,23 +211,23 @@ func (ht *HonestChallengeTree) ComputeAncestorsWithTimers(
 		}, nil
 	}
 
-	// If the ancestry list is non-empty, the last edge in the ancestry should
-	// be the honest block challenge level root edge we agree with. We perform this
-	// safety check at the end of this function to ensure we are returning
-	// a proper ancestry list.
-	if ht.honestBlockChalLevelZeroEdge.IsNone() {
-		// Should never happen, but is just an extra check against panics.
-		return nil, errors.New("no honest block challenge root edge found")
-	}
-	rootChallengeEdgeId := ht.honestBlockChalLevelZeroEdge.Unwrap().Id()
-	lastAncestryEdgeId := ancestry[len(ancestry)-1]
-	if rootChallengeEdgeId != lastAncestryEdgeId {
-		return nil, fmt.Errorf(
-			"last edge in ancestry %#x is not the top-level, root honest edge %#x",
-			lastAncestryEdgeId,
-			rootChallengeEdgeId,
-		)
-	}
+	// // If the ancestry list is non-empty, the last edge in the ancestry should
+	// // be the honest block challenge level root edge we agree with. We perform this
+	// // safety check at the end of this function to ensure we are returning
+	// // a proper ancestry list.
+	// if ht.honestBlockChalLevelZeroEdge.IsNone() {
+	// 	// Should never happen, but is just an extra check against panics.
+	// 	return nil, errors.New("no honest block challenge root edge found")
+	// }
+	// rootChallengeEdgeId := ht.honestBlockChalLevelZeroEdge.Unwrap().Id()
+	// lastAncestryEdgeId := ancestry[len(ancestry)-1]
+	// if rootChallengeEdgeId != lastAncestryEdgeId {
+	// 	return nil, fmt.Errorf(
+	// 		"last edge in ancestry %#x is not the top-level, root honest edge %#x",
+	// 		lastAncestryEdgeId,
+	// 		rootChallengeEdgeId,
+	// 	)
+	// }
 	return &AncestorsQueryResponse{
 		AncestorLocalTimers: localTimers,
 		AncestorEdgeIds:     ancestry,
@@ -313,15 +313,15 @@ func (ht *HonestChallengeTree) honestRootAncestorAtChallengeLevel(
 	challengeLevel protocol.ChallengeLevel,
 ) (protocol.ReadOnlyEdge, error) {
 	originId := childEdge.OriginId()
-	// If the challenge level is the block challenge level (the highest), then there
-	// is only a single, honest block challenge edge.
-	if challengeLevel == protocol.ChallengeLevel(ht.totalChallengeLevels)-1 {
-		if ht.honestBlockChalLevelZeroEdge.IsNone() {
-			return nil, errNoLevelZero(originId)
-		}
-		return ht.honestBlockChalLevelZeroEdge.Unwrap(), nil
-	}
-	// Otherwise, finds the honest root edge at the appropriate challenge level.
+	// // If the challenge level is the block challenge level (the highest), then there
+	// // is only a single, honest block challenge edge.
+	// if challengeLevel == protocol.ChallengeLevel(ht.totalChallengeLevels)-1 {
+	// 	if ht.honestBlockChalLevelZeroEdge.IsNone() {
+	// 		return nil, errNoLevelZero(originId)
+	// 	}
+	// 	return ht.honestBlockChalLevelZeroEdge.Unwrap(), nil
+	// }
+	// // Otherwise, finds the honest root edge at the appropriate challenge level.
 	rootEdgesAtLevel, ok := ht.honestRootEdgesByLevel.TryGet(challengeLevel)
 	if !ok || rootEdgesAtLevel == nil {
 		return nil, fmt.Errorf("no honest edges found at challenge level %d", challengeLevel)

--- a/challenge-manager/challenge-tree/generalized_path_timer.go
+++ b/challenge-manager/challenge-tree/generalized_path_timer.go
@@ -132,10 +132,6 @@ func (ht *HonestChallengeTree) ComputeAncestorsWithTimers(
 	edgeId protocol.EdgeId,
 	blockNumber uint64,
 ) (*AncestorsQueryResponse, error) {
-	// // Checks if we have a block challenge root edge.
-	// if ht.honestBlockChalLevelZeroEdge.IsNone() {
-	// 	return nil, ErrNoHonestTopLevelEdge
-	// }
 	// Checks if the edge exists before performing any computation.
 	startEdge, ok := ht.edges.TryGet(edgeId)
 	if !ok {
@@ -211,23 +207,6 @@ func (ht *HonestChallengeTree) ComputeAncestorsWithTimers(
 		}, nil
 	}
 
-	// // If the ancestry list is non-empty, the last edge in the ancestry should
-	// // be the honest block challenge level root edge we agree with. We perform this
-	// // safety check at the end of this function to ensure we are returning
-	// // a proper ancestry list.
-	// if ht.honestBlockChalLevelZeroEdge.IsNone() {
-	// 	// Should never happen, but is just an extra check against panics.
-	// 	return nil, errors.New("no honest block challenge root edge found")
-	// }
-	// rootChallengeEdgeId := ht.honestBlockChalLevelZeroEdge.Unwrap().Id()
-	// lastAncestryEdgeId := ancestry[len(ancestry)-1]
-	// if rootChallengeEdgeId != lastAncestryEdgeId {
-	// 	return nil, fmt.Errorf(
-	// 		"last edge in ancestry %#x is not the top-level, root honest edge %#x",
-	// 		lastAncestryEdgeId,
-	// 		rootChallengeEdgeId,
-	// 	)
-	// }
 	return &AncestorsQueryResponse{
 		AncestorLocalTimers: localTimers,
 		AncestorEdgeIds:     ancestry,
@@ -313,14 +292,6 @@ func (ht *HonestChallengeTree) honestRootAncestorAtChallengeLevel(
 	challengeLevel protocol.ChallengeLevel,
 ) (protocol.ReadOnlyEdge, error) {
 	originId := childEdge.OriginId()
-	// // If the challenge level is the block challenge level (the highest), then there
-	// // is only a single, honest block challenge edge.
-	// if challengeLevel == protocol.ChallengeLevel(ht.totalChallengeLevels)-1 {
-	// 	if ht.honestBlockChalLevelZeroEdge.IsNone() {
-	// 		return nil, errNoLevelZero(originId)
-	// 	}
-	// 	return ht.honestBlockChalLevelZeroEdge.Unwrap(), nil
-	// }
 	// // Otherwise, finds the honest root edge at the appropriate challenge level.
 	rootEdgesAtLevel, ok := ht.honestRootEdgesByLevel.TryGet(challengeLevel)
 	if !ok || rootEdgesAtLevel == nil {

--- a/challenge-manager/challenge-tree/tree_test.go
+++ b/challenge-manager/challenge-tree/tree_test.go
@@ -22,12 +22,10 @@ import (
 
 func TestAddEdge(t *testing.T) {
 	ht := &HonestChallengeTree{
-		edges:                         threadsafe.NewMap[protocol.EdgeId, protocol.SpecEdge](),
-		mutualIds:                     threadsafe.NewMap[protocol.MutualId, *threadsafe.Map[protocol.EdgeId, creationTime]](),
-		honestBigStepLevelZeroEdges:   threadsafe.NewSlice[protocol.ReadOnlyEdge](),
-		honestSmallStepLevelZeroEdges: threadsafe.NewSlice[protocol.ReadOnlyEdge](),
-		honestRootEdgesByLevel:        threadsafe.NewMap[protocol.ChallengeLevel, *threadsafe.Slice[protocol.ReadOnlyEdge]](),
-		totalChallengeLevels:          3,
+		edges:                  threadsafe.NewMap[protocol.EdgeId, protocol.SpecEdge](),
+		mutualIds:              threadsafe.NewMap[protocol.MutualId, *threadsafe.Map[protocol.EdgeId, creationTime]](),
+		honestRootEdgesByLevel: threadsafe.NewMap[protocol.ChallengeLevel, *threadsafe.Slice[protocol.ReadOnlyEdge]](),
+		totalChallengeLevels:   3,
 	}
 	ht.topLevelAssertionHash = protocol.AssertionHash{Hash: common.BytesToHash([]byte("foo"))}
 	ctx := context.Background()
@@ -207,9 +205,7 @@ func TestAddEdge(t *testing.T) {
 		require.Equal(t, true, ok)
 
 		// However, we should not have a level zero edge being tracked yet.
-		require.Equal(t, true, ht.honestBlockChalLevelZeroEdge.IsNone())
-		require.Equal(t, true, ht.honestBigStepLevelZeroEdges.Len() == 0)
-		require.Equal(t, true, ht.honestSmallStepLevelZeroEdges.Len() == 0)
+		require.Equal(t, true, ht.honestRootEdgesByLevel.IsEmpty())
 	})
 	t.Run("agrees with edge and is a level zero edge", func(t *testing.T) {
 		ht.metadataReader = &mockMetadataReader{
@@ -262,7 +258,9 @@ func TestAddEdge(t *testing.T) {
 		require.Equal(t, true, ok)
 
 		// We should have a level zero edge being tracked.
-		require.Equal(t, false, ht.honestBlockChalLevelZeroEdge.IsNone())
+		require.Equal(t, false, ht.honestRootEdgesByLevel.IsEmpty())
+		_, ok = ht.honestRootEdgesByLevel.TryGet(protocol.ChallengeLevel(2))
+		require.Equal(t, true, ok)
 	})
 	t.Run("edge is not honest but we agree with start commit and keep it as a rival", func(t *testing.T) {
 		ht.metadataReader = &mockMetadataReader{
@@ -332,11 +330,9 @@ func TestAddHonestEdge(t *testing.T) {
 	createdAt := uint64(1)
 	edge := newEdge(&newCfg{t: t, edgeId: "big-0.a-32.a", createdAt: createdAt, claimId: "bar"})
 	ht := &HonestChallengeTree{
-		edges:                         threadsafe.NewMap[protocol.EdgeId, protocol.SpecEdge](),
-		mutualIds:                     threadsafe.NewMap[protocol.MutualId, *threadsafe.Map[protocol.EdgeId, creationTime]](),
-		honestBigStepLevelZeroEdges:   threadsafe.NewSlice[protocol.ReadOnlyEdge](),
-		honestSmallStepLevelZeroEdges: threadsafe.NewSlice[protocol.ReadOnlyEdge](),
-		honestRootEdgesByLevel:        threadsafe.NewMap[protocol.ChallengeLevel, *threadsafe.Slice[protocol.ReadOnlyEdge]](),
+		edges:                  threadsafe.NewMap[protocol.EdgeId, protocol.SpecEdge](),
+		mutualIds:              threadsafe.NewMap[protocol.MutualId, *threadsafe.Map[protocol.EdgeId, creationTime]](),
+		honestRootEdgesByLevel: threadsafe.NewMap[protocol.ChallengeLevel, *threadsafe.Slice[protocol.ReadOnlyEdge]](),
 	}
 	ht.topLevelAssertionHash = protocol.AssertionHash{Hash: common.BytesToHash([]byte("foo"))}
 	honest := &mockHonestEdge{edge}

--- a/challenge-manager/challenges.go
+++ b/challenge-manager/challenges.go
@@ -102,7 +102,7 @@ func (m *Manager) addBlockChallengeLevelZeroEdge(
 	if err != nil {
 		return nil, nil, err
 	}
-	levelZeroBlockEdgeHeight, err := manager.LevelZeroBlockEdgeHeight(ctx)
+	layerZeroHeights, err := manager.LayerZeroHeights(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -111,7 +111,7 @@ func (m *Manager) addBlockChallengeLevelZeroEdge(
 		Batch:                       l2stateprovider.Batch(creationInfo.InboxMaxCount.Uint64()),
 		UpperChallengeOriginHeights: []l2stateprovider.Height{},
 		FromHeight:                  l2stateprovider.Height(parentAssertionAfterState.GlobalState.Batch),
-		UpToHeight:                  option.Some(l2stateprovider.Height(parentAssertionAfterState.GlobalState.Batch + levelZeroBlockEdgeHeight)),
+		UpToHeight:                  option.Some(l2stateprovider.Height(parentAssertionAfterState.GlobalState.Batch + layerZeroHeights.BlockChallengeHeight)),
 	}
 	endCommit, err := m.stateManager.HistoryCommitment(
 		ctx,

--- a/challenge-manager/manager.go
+++ b/challenge-manager/manager.go
@@ -171,21 +171,10 @@ func New(
 	if err != nil {
 		return nil, err
 	}
-	managerBindings, err := challengeV2gen.NewEdgeChallengeManagerCaller(chalManagerAddr, backend)
+	numBigStepLevels, err := chalManager.NumBigSteps(ctx)
 	if err != nil {
 		return nil, err
 	}
-	numBigStepLevelsRaw, err := managerBindings.NUMBIGSTEPLEVEL(&bind.CallOpts{Context: ctx})
-	if err != nil {
-		return nil, err
-	}
-	if !numBigStepLevelsRaw.IsUint64() {
-		return nil, errors.New("NUMBIGSTEPLEVEL returned non-uint64 value")
-	}
-	if numBigStepLevelsRaw.Uint64() > 256 {
-		return nil, errors.New("NUMBIGSTEPLEVEL returned value greater than 256")
-	}
-	numBigStepLevels := uint8(numBigStepLevelsRaw.Uint64())
 	m.rollup = rollup
 	m.rollupFilterer = rollupFilterer
 	m.chalManagerAddr = chalManagerAddr

--- a/challenge-manager/manager_test.go
+++ b/challenge-manager/manager_test.go
@@ -13,9 +13,11 @@ import (
 	watcher "github.com/OffchainLabs/bold/challenge-manager/chain-watcher"
 	edgetracker "github.com/OffchainLabs/bold/challenge-manager/edge-tracker"
 	"github.com/OffchainLabs/bold/challenge-manager/types"
+	"github.com/OffchainLabs/bold/solgen/go/challengeV2gen"
 	"github.com/OffchainLabs/bold/testing/mocks"
 	"github.com/OffchainLabs/bold/testing/setup"
 	customTime "github.com/OffchainLabs/bold/time"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/stretchr/testify/require"
 )
 
@@ -92,7 +94,15 @@ func setupNonPSTracker(ctx context.Context, t *testing.T) (*edgetracker.Tracker,
 	require.NoError(t, err)
 	require.Equal(t, false, !hasRival)
 
-	honestWatcher := watcher.New(honestValidator.chain, honestValidator, honestValidator.stateManager, createdData.Backend, time.Second, "alice")
+	chalManager, err := createdData.Chains[0].SpecChallengeManager(ctx)
+	require.NoError(t, err)
+	managerBindings, err := challengeV2gen.NewEdgeChallengeManagerCaller(chalManager.Address(), createdData.Backend)
+	require.NoError(t, err)
+	numBigStepLevelsRaw, err := managerBindings.NUMBIGSTEPLEVEL(&bind.CallOpts{Context: ctx})
+	require.NoError(t, err)
+	numBigStepLevels := uint8(numBigStepLevelsRaw.Uint64())
+
+	honestWatcher := watcher.New(honestValidator.chain, honestValidator, honestValidator.stateManager, createdData.Backend, time.Second, numBigStepLevels, "alice")
 	honestValidator.watcher = honestWatcher
 	tracker1, err := edgetracker.New(
 		ctx,
@@ -118,7 +128,7 @@ func setupNonPSTracker(ctx context.Context, t *testing.T) (*edgetracker.Tracker,
 		time.Sleep(time.Millisecond * 10)
 	}
 
-	evilWatcher := watcher.New(evilValidator.chain, evilValidator, evilValidator.stateManager, createdData.Backend, time.Second, "alice")
+	evilWatcher := watcher.New(evilValidator.chain, evilValidator, evilValidator.stateManager, createdData.Backend, time.Second, numBigStepLevels, "alice")
 	evilValidator.watcher = evilWatcher
 	tracker2, err := edgetracker.New(
 		ctx,

--- a/challenge-manager/manager_test.go
+++ b/challenge-manager/manager_test.go
@@ -160,8 +160,10 @@ func setupValidator(t *testing.T) (*Manager, *mocks.MockProtocol, *mocks.MockSta
 	t.Helper()
 	p := &mocks.MockProtocol{}
 	ctx := context.Background()
-	p.On("CurrentChallengeManager", ctx).Return(&mocks.MockChallengeManager{}, nil)
-	p.On("SpecChallengeManager", ctx).Return(&mocks.MockSpecChallengeManager{}, nil)
+	cm := &mocks.MockSpecChallengeManager{}
+	p.On("CurrentChallengeManager", ctx).Return(cm, nil)
+	p.On("SpecChallengeManager", ctx).Return(cm, nil)
+	cm.On("NumBigSteps", ctx).Return(uint8(1), nil)
 	s := &mocks.MockStateManager{}
 	cfg, err := setup.ChainsWithEdgeChallengeManager()
 	require.NoError(t, err)

--- a/containers/threadsafe/map.go
+++ b/containers/threadsafe/map.go
@@ -18,6 +18,12 @@ func NewMapFromItems[K comparable, V any](m map[K]V) *Map[K, V] {
 	return &Map[K, V]{items: m}
 }
 
+func (s *Map[K, V]) IsEmpty() bool {
+	s.RLock()
+	defer s.RUnlock()
+	return len(s.items) == 0
+}
+
 func (s *Map[K, V]) Put(k K, v V) {
 	s.Lock()
 	defer s.Unlock()

--- a/testing/BUILD.bazel
+++ b/testing/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/OffchainLabs/bold/testing",
     visibility = ["//visibility:public"],
     deps = [
+        "//chain-abstraction:protocol",
         "//solgen/go/rollupgen",
         "@com_github_ethereum_go_ethereum//accounts/abi/bind",
         "@com_github_ethereum_go_ethereum//accounts/abi/bind/backends",

--- a/testing/mocks/mocks.go
+++ b/testing/mocks/mocks.go
@@ -79,14 +79,10 @@ func (m *MockStateManager) PrefixProof(
 	args := m.Called(ctx, req, prefixHeight)
 	return args.Get(0).([]byte), args.Error(1)
 }
+
 func (m *MockStateManager) ExecutionStateAtMessageNumber(ctx context.Context, messageNumber uint64) (*protocol.ExecutionState, error) {
 	args := m.Called(ctx, messageNumber)
 	return args.Get(0).(*protocol.ExecutionState), args.Error(1)
-}
-
-func (m *MockStateManager) HistoryCommitmentAtMessage(ctx context.Context, height uint64) (commitments.History, error) {
-	args := m.Called(ctx, height)
-	return args.Get(0).(commitments.History), args.Error(1)
 }
 
 func (m *MockStateManager) AgreesWithHistoryCommitment(
@@ -99,82 +95,9 @@ func (m *MockStateManager) AgreesWithHistoryCommitment(
 	return args.Get(0).(bool), args.Error(1)
 }
 
-func (m *MockStateManager) HistoryCommitmentUpToBatch(ctx context.Context, startBlock, endBlock, batchCount uint64) (commitments.History, error) {
-	args := m.Called(ctx, startBlock, endBlock, batchCount)
-	return args.Get(0).(commitments.History), args.Error(1)
-}
-
-func (m *MockStateManager) PrefixProofUpToBatch(ctx context.Context, start, from, to, batchCount uint64) ([]byte, error) {
-	args := m.Called(ctx, start, from, to, batchCount)
-	return args.Get(0).([]byte), args.Error(1)
-}
-
-func (m *MockStateManager) BigStepPrefixProof(
-	ctx context.Context,
-	wasmModuleRoot common.Hash,
-	blockHeight,
-	fromBigStep,
-	toBigStep uint64,
-) ([]byte, error) {
-	args := m.Called(ctx, wasmModuleRoot, blockHeight, fromBigStep, toBigStep)
-	return args.Get(0).([]byte), args.Error(1)
-}
-
-func (m *MockStateManager) SmallStepPrefixProof(
-	ctx context.Context,
-	wasmModuleRoot common.Hash,
-	blockHeight,
-	bigStep,
-	fromSmallStep,
-	toSmallStep uint64,
-) ([]byte, error) {
-	args := m.Called(ctx, wasmModuleRoot, blockHeight, bigStep, fromSmallStep, toSmallStep)
-	return args.Get(0).([]byte), args.Error(1)
-}
-
 func (m *MockStateManager) ExecutionStateMsgCount(ctx context.Context, state *protocol.ExecutionState) (uint64, error) {
 	args := m.Called(ctx, state)
 	return args.Get(0).(uint64), args.Error(1)
-}
-
-func (m *MockStateManager) BigStepLeafCommitment(
-	ctx context.Context,
-	wasmModuleRoot common.Hash,
-	blockHeight uint64,
-) (commitments.History, error) {
-	args := m.Called(ctx, wasmModuleRoot, blockHeight)
-	return args.Get(0).(commitments.History), args.Error(1)
-}
-
-func (m *MockStateManager) BigStepCommitmentUpTo(
-	ctx context.Context,
-	wasmModuleRoot common.Hash,
-	blockHeight,
-	toBigStep uint64,
-) (commitments.History, error) {
-	args := m.Called(ctx, wasmModuleRoot, blockHeight, toBigStep)
-	return args.Get(0).(commitments.History), args.Error(1)
-}
-
-func (m *MockStateManager) SmallStepLeafCommitment(
-	ctx context.Context,
-	wasmModuleRoot common.Hash,
-	blockHeight,
-	bigStep uint64,
-) (commitments.History, error) {
-	args := m.Called(ctx, wasmModuleRoot, blockHeight, bigStep)
-	return args.Get(0).(commitments.History), args.Error(1)
-}
-
-func (m *MockStateManager) SmallStepCommitmentUpTo(
-	ctx context.Context,
-	wasmModuleRoot common.Hash,
-	blockHeight,
-	bigStep,
-	toSmallStep uint64,
-) (commitments.History, error) {
-	args := m.Called(ctx, wasmModuleRoot, blockHeight, bigStep, toSmallStep)
-	return args.Get(0).(commitments.History), args.Error(1)
 }
 
 func (m *MockStateManager) OneStepProofData(

--- a/testing/mocks/mocks.go
+++ b/testing/mocks/mocks.go
@@ -140,9 +140,14 @@ func (m *MockSpecChallengeManager) Address() common.Address {
 	return m.MockAddr
 }
 
-func (m *MockSpecChallengeManager) LevelZeroBlockEdgeHeight(ctx context.Context) (uint64, error) {
+func (m *MockSpecChallengeManager) NumBigSteps(ctx context.Context) (uint8, error) {
 	args := m.Called(ctx)
-	return args.Get(0).(uint64), args.Error(1)
+	return args.Get(0).(uint8), args.Error(1)
+}
+
+func (m *MockSpecChallengeManager) LayerZeroHeights(ctx context.Context) (*protocol.LayerZeroHeights, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(*protocol.LayerZeroHeights), args.Error(1)
 }
 
 func (m *MockSpecChallengeManager) ChallengePeriodBlocks(ctx context.Context) (uint64, error) {

--- a/testing/mocks/state-provider/history_provider_test.go
+++ b/testing/mocks/state-provider/history_provider_test.go
@@ -28,7 +28,6 @@ func TestHistoryCommitment(t *testing.T) {
 	stateBackend, err := newTestingMachine(
 		states,
 		WithMaxWavmOpcodesPerBlock(uint64(challengeLeafHeights[1]*challengeLeafHeights[2])),
-		WithNumOpcodesPerBigStep(uint64(challengeLeafHeights[2])),
 		WithMachineAtBlockProvider(mockMachineAtBlock),
 		WithForceMachineBlockCompat(),
 	)

--- a/testing/mocks/state-provider/layer2_state_provider.go
+++ b/testing/mocks/state-provider/layer2_state_provider.go
@@ -32,20 +32,17 @@ var (
 // state roots. It can produce state and history commitments from those roots.
 type L2StateBackend struct {
 	l2stateprovider.HistoryCommitmentProvider
-	stateRoots                   []common.Hash
-	executionStates              []*protocol.ExecutionState
-	machineAtBlock               func(context.Context, uint64) (Machine, error)
-	maxWavmOpcodes               uint64
-	numOpcodesPerBigStep         uint64
-	blockDivergenceHeight        uint64
-	posInBatchDivergence         int64
-	machineDivergenceStep        uint64
-	forceMachineBlockCompat      bool
-	levelZeroBlockEdgeHeight     uint64
-	levelZeroBigStepEdgeHeight   uint64
-	levelZeroSmallStepEdgeHeight uint64
-	maliciousMachineIndex        uint64
-	challengeLeafHeights         []l2stateprovider.Height
+	stateRoots              []common.Hash
+	executionStates         []*protocol.ExecutionState
+	machineAtBlock          func(context.Context, uint64) (Machine, error)
+	maxWavmOpcodes          uint64
+	blockDivergenceHeight   uint64
+	posInBatchDivergence    int64
+	machineDivergenceStep   uint64
+	forceMachineBlockCompat bool
+	maliciousMachineIndex   uint64
+	numBigSteps             uint64
+	challengeLeafHeights    []l2stateprovider.Height
 }
 
 // NewWithMockedStateRoots initialize with a list of predefined state roots, useful for tests and simulations.
@@ -58,6 +55,7 @@ func NewWithMockedStateRoots(stateRoots []common.Hash, opts ...Opt) (*L2StateBac
 		machineAtBlock: func(context.Context, uint64) (Machine, error) {
 			return nil, errors.New("state manager created with New() cannot provide machines")
 		},
+		numBigSteps: 1,
 		challengeLeafHeights: []l2stateprovider.Height{
 			challenge_testing.LevelZeroBlockEdgeHeight,
 			challenge_testing.LevelZeroBigStepEdgeHeight,
@@ -77,12 +75,6 @@ type Opt func(*L2StateBackend)
 func WithMaxWavmOpcodesPerBlock(maxOpcodes uint64) Opt {
 	return func(s *L2StateBackend) {
 		s.maxWavmOpcodes = maxOpcodes
-	}
-}
-
-func WithNumOpcodesPerBigStep(numOpcodes uint64) Opt {
-	return func(s *L2StateBackend) {
-		s.numOpcodesPerBigStep = numOpcodes
 	}
 }
 
@@ -117,11 +109,14 @@ func WithForceMachineBlockCompat() Opt {
 	}
 }
 
-func WithLevelZeroEdgeHeights(heights *challenge_testing.LevelZeroHeights) Opt {
+func WithLayerZeroHeights(heights *challenge_testing.LayerZeroHeights, numBigSteps uint64) Opt {
 	return func(s *L2StateBackend) {
-		s.levelZeroBlockEdgeHeight = heights.BlockChallengeHeight
-		s.levelZeroBigStepEdgeHeight = heights.BigStepChallengeHeight
-		s.levelZeroSmallStepEdgeHeight = heights.SmallStepChallengeHeight
+		challengeLeafHeights := make([]l2stateprovider.Height, 0)
+		challengeLeafHeights = append(challengeLeafHeights, l2stateprovider.Height(heights.BlockChallengeHeight))
+		for i := uint64(0); i < numBigSteps; i++ {
+			challengeLeafHeights = append(challengeLeafHeights, l2stateprovider.Height(heights.BigStepChallengeHeight))
+		}
+		challengeLeafHeights = append(challengeLeafHeights, l2stateprovider.Height(heights.SmallStepChallengeHeight))
 	}
 }
 
@@ -135,10 +130,7 @@ func NewForSimpleMachine(
 	opts ...Opt,
 ) (*L2StateBackend, error) {
 	s := &L2StateBackend{
-		levelZeroBlockEdgeHeight:     challenge_testing.LevelZeroBlockEdgeHeight,
-		levelZeroBigStepEdgeHeight:   challenge_testing.LevelZeroBigStepEdgeHeight,
-		levelZeroSmallStepEdgeHeight: challenge_testing.LevelZeroSmallStepEdgeHeight,
-		maliciousMachineIndex:        0,
+		maliciousMachineIndex: 0,
 		challengeLeafHeights: []l2stateprovider.Height{
 			challenge_testing.LevelZeroBlockEdgeHeight,
 			challenge_testing.LevelZeroBigStepEdgeHeight,
@@ -150,8 +142,11 @@ func NewForSimpleMachine(
 	for _, o := range opts {
 		o(s)
 	}
-	s.maxWavmOpcodes = s.levelZeroSmallStepEdgeHeight * s.levelZeroBigStepEdgeHeight
-	s.numOpcodesPerBigStep = s.levelZeroSmallStepEdgeHeight
+	totalWavmOpcodes := uint64(1)
+	for _, h := range s.challengeLeafHeights[1:] {
+		totalWavmOpcodes *= uint64(h)
+	}
+	s.maxWavmOpcodes = totalWavmOpcodes
 	if s.maxWavmOpcodes == 0 {
 		return nil, errors.New("maxWavmOpcodes cannot be zero")
 	}

--- a/testing/mocks/state-provider/layer2_state_provider.go
+++ b/testing/mocks/state-provider/layer2_state_provider.go
@@ -109,7 +109,7 @@ func WithForceMachineBlockCompat() Opt {
 	}
 }
 
-func WithLayerZeroHeights(heights *challenge_testing.LayerZeroHeights, numBigSteps uint64) Opt {
+func WithLayerZeroHeights(heights *protocol.LayerZeroHeights, numBigSteps uint64) Opt {
 	return func(s *L2StateBackend) {
 		challengeLeafHeights := make([]l2stateprovider.Height, 0)
 		challengeLeafHeights = append(challengeLeafHeights, l2stateprovider.Height(heights.BlockChallengeHeight))
@@ -117,6 +117,7 @@ func WithLayerZeroHeights(heights *challenge_testing.LayerZeroHeights, numBigSte
 			challengeLeafHeights = append(challengeLeafHeights, l2stateprovider.Height(heights.BigStepChallengeHeight))
 		}
 		challengeLeafHeights = append(challengeLeafHeights, l2stateprovider.Height(heights.SmallStepChallengeHeight))
+		s.challengeLeafHeights = challengeLeafHeights
 	}
 }
 

--- a/testing/mocks/state-provider/layer2_state_provider_test.go
+++ b/testing/mocks/state-provider/layer2_state_provider_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	protocol "github.com/OffchainLabs/bold/chain-abstraction"
+	l2stateprovider "github.com/OffchainLabs/bold/layer2-state-provider"
 	challenge_testing "github.com/OffchainLabs/bold/testing"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -86,9 +87,12 @@ func newTestingMachine(
 		machineAtBlock: func(context.Context, uint64) (Machine, error) {
 			return nil, errors.New("state manager created with NewWithAssertionStates() cannot provide machines")
 		},
-		levelZeroBlockEdgeHeight:     challenge_testing.LevelZeroBlockEdgeHeight,
-		levelZeroBigStepEdgeHeight:   challenge_testing.LevelZeroBigStepEdgeHeight,
-		levelZeroSmallStepEdgeHeight: challenge_testing.LevelZeroSmallStepEdgeHeight,
+		numBigSteps: 1,
+		challengeLeafHeights: []l2stateprovider.Height{
+			challenge_testing.LevelZeroBlockEdgeHeight,
+			challenge_testing.LevelZeroBigStepEdgeHeight,
+			challenge_testing.LevelZeroSmallStepEdgeHeight,
+		},
 	}
 	for _, o := range opts {
 		o(s)

--- a/testing/rollup_config.go
+++ b/testing/rollup_config.go
@@ -17,7 +17,7 @@ const (
 	MaxDataSize                  = 117964
 )
 
-type LevelZeroHeights struct {
+type LayerZeroHeights struct {
 	BlockChallengeHeight     uint64
 	BigStepChallengeHeight   uint64
 	SmallStepChallengeHeight uint64
@@ -28,6 +28,14 @@ type Opt func(c *rollupgen.Config)
 func WithNumBigStepLevels(num *big.Int) Opt {
 	return func(c *rollupgen.Config) {
 		c.NumBigStepLevel = num
+	}
+}
+
+func WithLayerZeroHeights(h *LayerZeroHeights) Opt {
+	return func(c *rollupgen.Config) {
+		c.LayerZeroBlockEdgeHeight = new(big.Int).SetUint64(h.BlockChallengeHeight)
+		c.LayerZeroBigStepEdgeHeight = new(big.Int).SetUint64(h.BigStepChallengeHeight)
+		c.LayerZeroSmallStepEdgeHeight = new(big.Int).SetUint64(h.SmallStepChallengeHeight)
 	}
 }
 

--- a/testing/rollup_config.go
+++ b/testing/rollup_config.go
@@ -6,6 +6,7 @@ package challenge_testing
 import (
 	"math/big"
 
+	protocol "github.com/OffchainLabs/bold/chain-abstraction"
 	"github.com/OffchainLabs/bold/solgen/go/rollupgen"
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -17,12 +18,6 @@ const (
 	MaxDataSize                  = 117964
 )
 
-type LayerZeroHeights struct {
-	BlockChallengeHeight     uint64
-	BigStepChallengeHeight   uint64
-	SmallStepChallengeHeight uint64
-}
-
 type Opt func(c *rollupgen.Config)
 
 func WithNumBigStepLevels(num *big.Int) Opt {
@@ -31,7 +26,7 @@ func WithNumBigStepLevels(num *big.Int) Opt {
 	}
 }
 
-func WithLayerZeroHeights(h *LayerZeroHeights) Opt {
+func WithLayerZeroHeights(h *protocol.LayerZeroHeights) Opt {
 	return func(c *rollupgen.Config) {
 		c.LayerZeroBlockEdgeHeight = new(big.Int).SetUint64(h.BlockChallengeHeight)
 		c.LayerZeroBigStepEdgeHeight = new(big.Int).SetUint64(h.BigStepChallengeHeight)


### PR DESCRIPTION
This PR cleans up some technical debt and removes some older references to hardcoded number of challenge levels. This also adds more configuration options to allow for N big step levels in the Go code