### PR TITLE
Add LRU Cache for `agreesWithStart` in `AddEdge`

### DIFF
--- a/challenge-manager/chain-watcher/BUILD.bazel
+++ b/challenge-manager/chain-watcher/BUILD.bazel
@@ -17,7 +17,7 @@ go_library(
         "@com_github_ethereum_go_ethereum//common",
         "@com_github_ethereum_go_ethereum//log",
         "@com_github_ethereum_go_ethereum//metrics",
-        "@com_github_hashicorp_golang_lru//:go_default_library",
+        "@com_github_hashicorp_golang_lru//:golang-lru",
         "@com_github_pkg_errors//:errors",
     ],
 )

--- a/challenge-manager/chain-watcher/BUILD.bazel
+++ b/challenge-manager/chain-watcher/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "@com_github_ethereum_go_ethereum//common",
         "@com_github_ethereum_go_ethereum//log",
         "@com_github_ethereum_go_ethereum//metrics",
+        "@com_github_hashicorp_golang_lru//:go_default_library",
         "@com_github_pkg_errors//:errors",
     ],
 )

--- a/challenge-manager/chain-watcher/watcher.go
+++ b/challenge-manager/chain-watcher/watcher.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/pkg/errors"
 )
 
@@ -97,6 +98,7 @@ type Watcher struct {
 	validatorName        string
 	numBigStepLevels     uint8
 	initialSyncCompleted atomic.Bool
+	junkCommitmentCache  *lru.Cache
 }
 
 // New initializes a watcher service for frequently scanning the chain
@@ -110,15 +112,17 @@ func New(
 	numBigStepLevels uint8,
 	validatorName string,
 ) *Watcher {
+	cache, _ := lru.New(2048)
 	return &Watcher{
-		chain:              chain,
-		edgeManager:        edgeManager,
-		pollEventsInterval: interval,
-		challenges:         threadsafe.NewMap[protocol.AssertionHash, *trackedChallenge](),
-		backend:            backend,
-		histChecker:        histChecker,
-		numBigStepLevels:   numBigStepLevels,
-		validatorName:      validatorName,
+		chain:               chain,
+		edgeManager:         edgeManager,
+		pollEventsInterval:  interval,
+		challenges:          threadsafe.NewMap[protocol.AssertionHash, *trackedChallenge](),
+		backend:             backend,
+		histChecker:         histChecker,
+		numBigStepLevels:    numBigStepLevels,
+		validatorName:       validatorName,
+		junkCommitmentCache: cache,
 	}
 }
 
@@ -449,12 +453,37 @@ func (w *Watcher) processEdgeAddedEvent(
 		}
 		w.challenges.Put(assertionHash, chal)
 	}
+
+	// Create a composite key from the start commitment and height
+	type commitHeightKey struct {
+		commit string
+		height uint64
+	}
+	startHeight, startCommitment := edge.StartCommitment()
+	key := commitHeightKey{
+		commit: startCommitment.String(),
+		height: uint64(startHeight),
+	}
+
+	// Check if the composite key exists in the junkCommitmentCache
+	// This is to short-circuit processing if we already know the commitment is "junk"
+	if _, ok := w.junkCommitmentCache.Get(key); ok {
+		// Cache hit: this startCommitment and height combination is known to be junk, skipping further processing
+		return nil
+	}
+
 	// Add the edge to a local challenge tree of tracked edges. If it is honest,
 	// we also spawn a tracker for the edge.
 	agreement, err := chal.honestEdgeTree.AddEdge(ctx, edge)
 	if err != nil {
 		return errors.Wrap(err, "could not add edge to challenge tree")
 	}
+
+	if !agreement.AgreesWithStartCommit {
+		// Cache miss: this startCommitment and height combination is determined to be junk, adding to cache for future short-circuit
+		w.junkCommitmentCache.Add(key, struct{}{})
+	}
+
 	if agreement.IsHonestEdge {
 		return w.edgeManager.TrackEdge(ctx, edge)
 	}

--- a/challenge-manager/chain-watcher/watcher.go
+++ b/challenge-manager/chain-watcher/watcher.go
@@ -479,7 +479,7 @@ func (w *Watcher) processEdgeAddedEvent(
 		return errors.Wrap(err, "could not add edge to challenge tree")
 	}
 
-	if !agreement.AgreesWithStartCommit {
+	if !agreement.AgreesWithStartCommit && key.height != 0 {
 		// Cache miss: this startCommitment and height combination is determined to be junk, adding to cache for future short-circuit
 		w.junkCommitmentCache.Add(key, struct{}{})
 	}

--- a/challenge-manager/chain-watcher/watcher_test.go
+++ b/challenge-manager/chain-watcher/watcher_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/OffchainLabs/bold/solgen/go/challengeV2gen"
 	"github.com/OffchainLabs/bold/testing/mocks"
 	"github.com/ethereum/go-ethereum/common"
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/stretchr/testify/require"
 )
 
@@ -168,11 +169,13 @@ func TestWatcher_processEdgeAddedEvent(t *testing.T) {
 	mockManager := &mocks.MockEdgeTracker{}
 	mockManager.On("TrackEdge", ctx, edge).Return(nil)
 
+	cache, _ := lru.New(1)
 	watcher := &Watcher{
-		challenges:  threadsafe.NewMap[protocol.AssertionHash, *trackedChallenge](),
-		histChecker: mockStateManager,
-		chain:       mockChain,
-		edgeManager: mockManager,
+		challenges:          threadsafe.NewMap[protocol.AssertionHash, *trackedChallenge](),
+		histChecker:         mockStateManager,
+		chain:               mockChain,
+		edgeManager:         mockManager,
+		junkCommitmentCache: cache,
 	}
 	err := watcher.processEdgeAddedEvent(ctx, &challengeV2gen.EdgeChallengeManagerEdgeAdded{
 		EdgeId:   edgeId.Hash,

--- a/challenge-manager/challenge-tree/tree.go
+++ b/challenge-manager/challenge-tree/tree.go
@@ -12,6 +12,7 @@ import (
 	protocol "github.com/OffchainLabs/bold/chain-abstraction"
 	"github.com/OffchainLabs/bold/containers/threadsafe"
 	l2stateprovider "github.com/OffchainLabs/bold/layer2-state-provider"
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/pkg/errors"
 )
 
@@ -31,14 +32,15 @@ type creationTime uint64
 // HonestChallengeTree keeps track of edges the honest node agrees with in a particular challenge.
 // All edges tracked in this data structure are part of the same, top-level assertion challenge.
 type HonestChallengeTree struct {
-	edges                  *threadsafe.Map[protocol.EdgeId, protocol.SpecEdge]
-	mutualIds              *threadsafe.Map[protocol.MutualId, *threadsafe.Map[protocol.EdgeId, creationTime]]
-	topLevelAssertionHash  protocol.AssertionHash
-	metadataReader         MetadataReader
-	histChecker            l2stateprovider.HistoryChecker
-	validatorName          string
-	totalChallengeLevels   uint8
-	honestRootEdgesByLevel *threadsafe.Map[protocol.ChallengeLevel, *threadsafe.Slice[protocol.ReadOnlyEdge]]
+	edges                         *threadsafe.Map[protocol.EdgeId, protocol.SpecEdge]
+	mutualIds                     *threadsafe.Map[protocol.MutualId, *threadsafe.Map[protocol.EdgeId, creationTime]]
+	topLevelAssertionHash         protocol.AssertionHash
+	metadataReader                MetadataReader
+	histChecker                   l2stateprovider.HistoryChecker
+	validatorName                 string
+	totalChallengeLevels          uint8
+	honestRootEdgesByLevel        *threadsafe.Map[protocol.ChallengeLevel, *threadsafe.Slice[protocol.ReadOnlyEdge]]
+	agreeWithStartCommitmentCache *lru.Cache
 }
 
 func New(
@@ -48,6 +50,7 @@ func New(
 	numBigStepLevels uint8,
 	validatorName string,
 ) *HonestChallengeTree {
+	cache, _ := lru.New(2048)
 	return &HonestChallengeTree{
 		edges:                 threadsafe.NewMap[protocol.EdgeId, protocol.SpecEdge](),
 		mutualIds:             threadsafe.NewMap[protocol.MutualId, *threadsafe.Map[protocol.EdgeId, creationTime]](),
@@ -56,14 +59,24 @@ func New(
 		histChecker:           histChecker,
 		validatorName:         validatorName,
 		// The total number of challenge levels include block challenges, small step challenges, and N big step challenges.
-		totalChallengeLevels:   numBigStepLevels + 2,
-		honestRootEdgesByLevel: threadsafe.NewMap[protocol.ChallengeLevel, *threadsafe.Slice[protocol.ReadOnlyEdge]](),
+		totalChallengeLevels:          numBigStepLevels + 2,
+		honestRootEdgesByLevel:        threadsafe.NewMap[protocol.ChallengeLevel, *threadsafe.Slice[protocol.ReadOnlyEdge]](),
+		agreeWithStartCommitmentCache: cache,
 	}
 }
 
 // AddEdge to the honest challenge tree. Only honest edges are tracked, but we also keep track
 // of rival ids in a mutual ids mapping internally for extra book-keeping.
 func (ht *HonestChallengeTree) AddEdge(ctx context.Context, eg protocol.SpecEdge) (protocol.Agreement, error) {
+	// Check if we already agree with the start commitment of this edge.
+	startHeight, startCommit := eg.StartCommitment()
+	if _, ok := ht.agreeWithStartCommitmentCache.Get(startCommit); ok {
+		return protocol.Agreement{
+			IsHonestEdge:          false,
+			AgreesWithStartCommit: false,
+		}, nil
+	}
+
 	if _, ok := ht.edges.TryGet(eg.Id()); ok {
 		// Already being tracked.
 		return protocol.Agreement{}, nil
@@ -85,7 +98,6 @@ func (ht *HonestChallengeTree) AddEdge(ctx context.Context, eg protocol.SpecEdge
 	}
 
 	// We only track edges we fully agree with (honest edges).
-	startHeight, startCommit := eg.StartCommitment()
 	endHeight, endCommit := eg.EndCommitment()
 	heights, err := ht.metadataReader.TopLevelClaimHeights(ctx, eg.Id())
 	if err != nil {
@@ -140,6 +152,11 @@ func (ht *HonestChallengeTree) AddEdge(ctx context.Context, eg protocol.SpecEdge
 	)
 	if err != nil {
 		return protocol.Agreement{}, errors.Wrapf(err, "could not check if agrees with history commit for edge %#x", eg.Id())
+	}
+
+	if !agreesWithStart {
+		// Add to cache if agreesWithStart is false
+		ht.agreeWithStartCommitmentCache.Add(startCommit, struct{}{})
 	}
 
 	// If we agree with the edge, we add it to our edges mapping and if it is level zero,

--- a/deps.bzl
+++ b/deps.bzl
@@ -1881,3 +1881,10 @@ def go_dependencies():
         sum = "h1:5Pf6pFKu98ODmgnpvkJ3kFUOQGGLIzLIkbzUHp47618=",
         version = "v0.0.0-20220517211312-f3a8303e98df",
     )
+
+    go_repository(
+        name = "com_github_hashicorp_golang_lru",
+        importpath = "github.com/hashicorp/golang-lru",
+        sum = "h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iPY6p1c=",
+        version = "v1.0.2",
+    )

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/ethereum/go-ethereum v1.12.0
 	github.com/gorilla/mux v1.8.0
+	github.com/hashicorp/golang-lru v1.0.2
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.2
 	golang.org/x/sync v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWm
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/go-bexpr v0.1.10 h1:9kuI5PFotCboP3dkDYFr/wi0gg0QVbSNz5oFRpxn4uE=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iPY6p1c=
+github.com/hashicorp/golang-lru v1.0.2/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/holiman/bloomfilter/v2 v2.0.3 h1:73e0e/V0tCydx14a0SCYS/EWCxgwLZ18CZcZKVu0fao=
 github.com/holiman/bloomfilter/v2 v2.0.3/go.mod h1:zpoh+gs7qcpqrHr3dB55AMiJwo0iURXE7ZOP9L9hSkA=


### PR DESCRIPTION
## Summary

This PR aims to optimize the `processEdgeAddedEvent` function by implementing an LRU cache, referred to as junkCommitmentCache. This cache stores composite keys made from `startCommitment` and `startHeight` for edges that don't agree with the start commitment (AgreesWithStartCommit is false). By doing this, the function can quickly short-circuit and avoid redundant and expensive operations when encountering these "junk" commitments again.

