### PR TITLE
Remove unused fsm states functions

### DIFF
--- a/challenge-manager/edge-tracker/fsm_states.go
+++ b/challenge-manager/edge-tracker/fsm_states.go
@@ -90,22 +90,3 @@ func (edgeAwaitConfirmation) String() string {
 func (edgeConfirm) String() string {
 	return "confirm"
 }
-
-func (edgeBackToStart) isEdgeTrackerAction() bool {
-	return true
-}
-func (edgeHandleOneStepProof) isEdgeTrackerAction() bool {
-	return true
-}
-func (edgeOpenSubchallengeLeaf) isEdgeTrackerAction() bool {
-	return true
-}
-func (edgeBisect) isEdgeTrackerAction() bool {
-	return true
-}
-func (edgeAwaitConfirmation) isEdgeTrackerAction() bool {
-	return true
-}
-func (edgeConfirm) isEdgeTrackerAction() bool {
-	return true
-}


### PR DESCRIPTION
Some functions in `fsm_states.go` I don't think there are any plans to use, so it's better to delete them for now.