### PR TITLE
Improve Flakey Challenge Manager Tests

### DIFF
--- a/chain-abstraction/sol-implementation/edge_challenge_manager.go
+++ b/chain-abstraction/sol-implementation/edge_challenge_manager.go
@@ -280,7 +280,7 @@ func (e *specEdge) ConfirmByTimer(ctx context.Context, ancestorIds []protocol.Ed
 			InboxAcc:          assertionCreation.AfterInboxBatchAcc,
 		})
 	})
-	return err
+	return errors.Wrapf(err, "could not confirm edge with tx and ancestors %v", ancestors)
 }
 
 func (e *specEdge) ConfirmByChildren(ctx context.Context) error {

--- a/challenge-manager/edge-tracker/tracker.go
+++ b/challenge-manager/edge-tracker/tracker.go
@@ -336,9 +336,7 @@ func (et *Tracker) Act(ctx context.Context) error {
 	case EdgeConfirming:
 		wasConfirmed, err := et.tryToConfirm(ctx)
 		if err != nil {
-			fields["err"] = err
-			//srvlog.Debug("Could not confirm edge yet", fields)
-			return et.fsm.Do(edgeAwaitConfirmation{})
+			return err
 		}
 		if !wasConfirmed {
 			return et.fsm.Do(edgeAwaitConfirmation{})

--- a/challenge-manager/edge-tracker/tracker.go
+++ b/challenge-manager/edge-tracker/tracker.go
@@ -503,7 +503,6 @@ func (et *Tracker) tryToConfirm(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, errors.Wrap(err, "could not check the challenge period length")
 	}
-	fmt.Printf("timer: %d, chalPeriod: %d\n", timer, chalPeriod)
 	if timer >= challengetree.PathTimer(chalPeriod) {
 		if err := et.edge.ConfirmByTimer(ctx, ancestors); err != nil {
 			return false, errors.Wrapf(err, "could not confirm by timer: got timer %d, chal period %d", timer, chalPeriod)

--- a/challenge-manager/edge-tracker/tracker.go
+++ b/challenge-manager/edge-tracker/tracker.go
@@ -241,9 +241,7 @@ func (et *Tracker) Act(ctx context.Context) error {
 		wasConfirmed, err := et.tryToConfirm(ctx)
 		if err != nil {
 			fields["err"] = err
-			if errors.Is(err, errNotYetConfirmable) {
-				//srvlog.Debug("Edge not yet confirmable", fields)
-			} else {
+			if !errors.Is(err, errNotYetConfirmable) {
 				srvlog.Error("Could not check if edge can be confirmed", fields)
 			}
 		}
@@ -505,6 +503,7 @@ func (et *Tracker) tryToConfirm(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, errors.Wrap(err, "could not check the challenge period length")
 	}
+	fmt.Printf("timer: %d, chalPeriod: %d\n", timer, chalPeriod)
 	if timer >= challengetree.PathTimer(chalPeriod) {
 		if err := et.edge.ConfirmByTimer(ctx, ancestors); err != nil {
 			return false, errors.Wrapf(err, "could not confirm by timer: got timer %d, chal period %d", timer, chalPeriod)

--- a/challenge-manager/manager_test.go
+++ b/challenge-manager/manager_test.go
@@ -168,7 +168,16 @@ func TestEdgeTracker_Act_ShouldDespawn_HasConfirmableAncestor(t *testing.T) {
 	require.Equal(t, true, childTracker2.ShouldDespawn(ctx))
 
 	// We check we can also confirm the ancestor edge.
-	err = tkr.Act(ctx)
+	// Retry a few times as the edge may not be confirmable right away.
+	numRetries := 10
+	for i := 0; i < numRetries; i++ {
+		err = tkr.Act(ctx)
+		if err != nil {
+			t.Logf("Got error: %v", err)
+			continue
+		}
+		break
+	}
 	require.NoError(t, err)
 	require.Equal(t, edgetracker.EdgeConfirmed, tkr.CurrentState())
 	require.Equal(t, true, tkr.ShouldDespawn(ctx))


### PR DESCRIPTION
This PR fixes a flake by instead manually adding edges to the chain watcher during a unit test to prevent races. This allows us to verify tests such as `HasConfirmableAncestor`