### PR TITLE
Fix Batch / Message Number Uses in BOLD

### DIFF
--- a/challenge-manager/challenge-tree/tree.go
+++ b/challenge-manager/challenge-tree/tree.go
@@ -144,10 +144,11 @@ func (ht *HonestChallengeTree) AddEdge(ctx context.Context, eg protocol.SpecEdge
 		}
 		// If this is a subchallenge, the first element of the start heights must account for the batch
 		// it corresponds to in the assertion chain.
-		startHeights[0] += l2stateprovider.Height(parentAssertionAfterState.GlobalState.Batch)
+		afterState := protocol.GoGlobalStateFromSolidity(creationInfo.AfterState.GlobalState)
+		startHeights[0] += l2stateprovider.Height(parentAssertionInfo.InboxMaxCount.Uint64())
 		request := &l2stateprovider.HistoryCommitmentRequest{
 			WasmModuleRoot:              creationInfo.WasmModuleRoot,
-			Batch:                       l2stateprovider.Batch(creationInfo.InboxMaxCount.Uint64()),
+			Batch:                       l2stateprovider.Batch(afterState.Batch),
 			FromHeight:                  l2stateprovider.Height(0),
 			UpperChallengeOriginHeights: startHeights,
 			UpToHeight:                  option.Some(l2stateprovider.Height(endHeight)),

--- a/challenge-manager/challenges.go
+++ b/challenge-manager/challenges.go
@@ -41,6 +41,8 @@ func (m *Manager) ChallengeAssertion(ctx context.Context, id protocol.AssertionH
 		}
 		srvlog.Error("could not add verified honest edge with id %#x to chain watcher: %w", fields)
 	}
+	afterState := protocol.GoGlobalStateFromSolidity(creationInfo.AfterState.GlobalState)
+
 	// Start tracking the challenge.
 	tracker, err := edgetracker.New(
 		ctx,
@@ -50,8 +52,8 @@ func (m *Manager) ChallengeAssertion(ctx context.Context, id protocol.AssertionH
 		m.watcher,
 		m,
 		edgetracker.HeightConfig{
-			StartBlockHeight: 0,
-			InboxMaxCount:    creationInfo.InboxMaxCount.Uint64() + 1,
+			MessageNumber: creationInfo.InboxMaxCount.Uint64(),
+			Batch:         afterState.Batch,
 		},
 		edgetracker.WithActInterval(m.edgeTrackerWakeInterval),
 		edgetracker.WithTimeReference(m.timeRef),

--- a/challenge-manager/manager.go
+++ b/challenge-manager/manager.go
@@ -292,7 +292,8 @@ func (m *Manager) getTrackerForEdge(ctx context.Context, edge protocol.SpecEdge)
 			return nil, heightErr
 		}
 		messageNumber = height
-		batch = assertionCreationInfo.InboxMaxCount.Uint64() + 1
+		afterState := protocol.GoGlobalStateFromSolidity(assertionCreationInfo.AfterState.GlobalState)
+		batch = afterState.Batch
 		m.assertionHashCache.Put(assertionHash, [2]uint64{messageNumber, batch})
 	} else {
 		messageNumber, batch = cachedHeightAndInboxMsgCount[0], cachedHeightAndInboxMsgCount[1]

--- a/challenge-manager/manager_test.go
+++ b/challenge-manager/manager_test.go
@@ -141,8 +141,8 @@ func TestEdgeTracker_Act_ShouldDespawn_HasConfirmableAncestor(t *testing.T) {
 		tkr.Watcher(),
 		tkr.ChallengeManager(),
 		edgetracker.HeightConfig{
-			StartBlockHeight: 0,
-			InboxMaxCount:    1,
+			MessageNumber: 0,
+			Batch:         1,
 		},
 		edgetracker.WithTimeReference(customTime.NewArtificialTimeReference()),
 	)
@@ -155,8 +155,8 @@ func TestEdgeTracker_Act_ShouldDespawn_HasConfirmableAncestor(t *testing.T) {
 		tkr.Watcher(),
 		tkr.ChallengeManager(),
 		edgetracker.HeightConfig{
-			StartBlockHeight: 0,
-			InboxMaxCount:    1,
+			MessageNumber: 0,
+			Batch:         1,
 		},
 		edgetracker.WithTimeReference(customTime.NewArtificialTimeReference()),
 	)
@@ -186,8 +186,8 @@ func Test_getEdgeTrackers(t *testing.T) {
 	trk, err := v.getTrackerForEdge(ctx, protocol.SpecEdge(edge))
 	require.NoError(t, err)
 
-	require.Equal(t, uint64(1), trk.StartBlockHeight())
-	require.Equal(t, uint64(0x65), trk.InboxMaxCount())
+	require.Equal(t, uint64(1), trk.MessageNumber())
+	require.Equal(t, uint64(0x65), trk.Batch())
 }
 
 func setupEdgeTrackersForBisection(
@@ -258,8 +258,8 @@ func setupEdgeTrackersForBisection(
 		honestWatcher,
 		honestValidator,
 		edgetracker.HeightConfig{
-			StartBlockHeight: 0,
-			InboxMaxCount:    1,
+			MessageNumber: 0,
+			Batch:         1,
 		},
 		edgetracker.WithTimeReference(customTime.NewArtificialTimeReference()),
 		edgetracker.WithValidatorName(honestValidator.name),
@@ -284,8 +284,8 @@ func setupEdgeTrackersForBisection(
 		evilWatcher,
 		evilValidator,
 		edgetracker.HeightConfig{
-			StartBlockHeight: 0,
-			InboxMaxCount:    1,
+			MessageNumber: 0,
+			Batch:         1,
 		},
 		edgetracker.WithTimeReference(customTime.NewArtificialTimeReference()),
 		edgetracker.WithValidatorName(evilValidator.name),


### PR DESCRIPTION
This PR fixes issues in batch and message number uses in BOLD, which were found to be wrong during the Nitro integration. The inbox max count tells us the message number, and the global state batch tells us the batch