### PR TITLE
Challenge by creating own assertion

### DIFF
--- a/assertions/scanner.go
+++ b/assertions/scanner.go
@@ -203,11 +203,24 @@ func (s *Scanner) ProcessAssertionCreation(
 	if err != nil {
 		return err
 	}
+
 	hasSecondChild, err := prevAssertion.HasSecondChild()
 	if err != nil {
 		return err
 	}
 	if !hasSecondChild {
+		parentAssertionCreationInfo, err := s.chain.ReadAssertionCreationInfo(ctx, prevAssertion.Id())
+		if err != nil {
+			return err
+		}
+		newState, err := s.stateProvider.ExecutionStateAtMessageNumber(ctx, parentAssertionCreationInfo.InboxMaxCount.Uint64())
+		if err != nil {
+			return err
+		}
+		if newState.GlobalState.BlockHash != goGs.BlockHash {
+			// We don't agree with the assertion, so we should post our own and challenge it.
+			// Only if you are a defensive or make mode challenge manager.
+		}
 		srvlog.Info("No fork detected in assertion chain", log.Ctx{"validatorName": s.validatorName})
 		return nil
 	}


### PR DESCRIPTION
Prior to this change, we solely relied on monitoring for new child assertions under a parent. When a parent assertion had two children, we initiated a challenge. However, this approach was limited. To extend beyond this case, we should

- Listens for new assertions in the system.
- Computes the post-state based on the new assertion.
- Compares the computed post-state with the expected state.
- Initiates a challenge if there is a discrepancy.


