### PR TITLE
Estimate Gas Before Sending Txs + Add Minor Protections

### DIFF
--- a/assertions/poster.go
+++ b/assertions/poster.go
@@ -31,13 +31,16 @@ func NewPoster(
 	stateManager l2stateprovider.ExecutionProvider,
 	validatorName string,
 	postInterval time.Duration,
-) *Poster {
+) (*Poster, error) {
+	if postInterval == 0 {
+		return nil, errors.New("assertion posting interval must be greater than 0")
+	}
 	return &Poster{
 		chain:         chain,
 		stateManager:  stateManager,
 		validatorName: validatorName,
 		postInterval:  postInterval,
-	}
+	}, nil
 }
 
 func (p *Poster) Start(ctx context.Context) {

--- a/assertions/scanner.go
+++ b/assertions/scanner.go
@@ -62,7 +62,13 @@ func NewScanner(
 	validatorName string,
 	pollInterval,
 	assertionConfirmationAttemptInterval time.Duration,
-) *Scanner {
+) (*Scanner, error) {
+	if pollInterval == 0 {
+		return nil, errors.New("assertion scanning interval must be greater than 0")
+	}
+	if assertionConfirmationAttemptInterval == 0 {
+		return nil, errors.New("assertion confirmation attempt interval must be greater than 0")
+	}
 	return &Scanner{
 		chain:                       chain,
 		backend:                     backend,
@@ -76,7 +82,7 @@ func NewScanner(
 		forksDetectedCount:          0,
 		challengesSubmittedCount:    0,
 		assertionsProcessedCount:    0,
-	}
+	}, nil
 }
 
 // Start scanning the blockchain for assertion creation events in a polling manner

--- a/assertions/scanner_test.go
+++ b/assertions/scanner_test.go
@@ -47,9 +47,10 @@ func TestScanner_ProcessAssertionCreation(t *testing.T) {
 		}, nil)
 		p.On("GetAssertion", ctx, mockId(2)).Return(ev, nil)
 		p.On("GetAssertion", ctx, mockId(1)).Return(prev, nil)
-		scanner := assertions.NewScanner(p, mockStateProvider, cfg.Backend, manager, cfg.Addrs.Rollup, "", time.Second, time.Second)
+		scanner, err := assertions.NewScanner(p, mockStateProvider, cfg.Backend, manager, cfg.Addrs.Rollup, "", time.Second, time.Second)
+		require.NoError(t, err)
 
-		err := scanner.ProcessAssertionCreation(ctx, ev.Id())
+		err = scanner.ProcessAssertionCreation(ctx, ev.Id())
 		require.NoError(t, err)
 		require.Equal(t, uint64(1), scanner.AssertionsProcessed())
 		require.Equal(t, uint64(0), scanner.ForksDetected())
@@ -72,7 +73,8 @@ func TestScanner_ProcessAssertionCreation(t *testing.T) {
 			challengemanager.WithEdgeTrackerWakeInterval(100*time.Millisecond),
 		)
 		require.NoError(t, err)
-		scanner := assertions.NewScanner(createdData.Chains[1], createdData.HonestStateManager, createdData.Backend, manager, createdData.Addrs.Rollup, "", time.Second, time.Second)
+		scanner, err := assertions.NewScanner(createdData.Chains[1], createdData.HonestStateManager, createdData.Backend, manager, createdData.Addrs.Rollup, "", time.Second, time.Second)
+		require.NoError(t, err)
 
 		err = scanner.ProcessAssertionCreation(ctx, createdData.Leaf1.Id())
 		require.NoError(t, err)
@@ -88,7 +90,8 @@ func TestScanner_ProcessAssertionCreation(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		otherScanner := assertions.NewScanner(createdData.Chains[0], createdData.EvilStateManager, createdData.Backend, otherManager, createdData.Addrs.Rollup, "", time.Second, time.Second)
+		otherScanner, err := assertions.NewScanner(createdData.Chains[0], createdData.EvilStateManager, createdData.Backend, otherManager, createdData.Addrs.Rollup, "", time.Second, time.Second)
+		require.NoError(t, err)
 
 		err = otherScanner.ProcessAssertionCreation(ctx, createdData.Leaf2.Id())
 		require.NoError(t, err)
@@ -117,7 +120,8 @@ func TestScanner_ProcessAssertionCreation(t *testing.T) {
 			challengemanager.WithEdgeTrackerWakeInterval(100*time.Millisecond),
 		)
 		require.NoError(t, err)
-		scanner := assertions.NewScanner(createdData.Chains[1], createdData.HonestStateManager, createdData.Backend, manager, createdData.Addrs.Rollup, "", time.Second, time.Second)
+		scanner, err := assertions.NewScanner(createdData.Chains[1], createdData.HonestStateManager, createdData.Backend, manager, createdData.Addrs.Rollup, "", time.Second, time.Second)
+		require.NoError(t, err)
 
 		err = scanner.ProcessAssertionCreation(ctx, createdData.Leaf1.Id())
 		require.NoError(t, err)
@@ -133,7 +137,8 @@ func TestScanner_ProcessAssertionCreation(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		otherScanner := assertions.NewScanner(createdData.Chains[0], createdData.EvilStateManager, createdData.Backend, otherManager, createdData.Addrs.Rollup, "", time.Second, time.Second)
+		otherScanner, err := assertions.NewScanner(createdData.Chains[0], createdData.EvilStateManager, createdData.Backend, otherManager, createdData.Addrs.Rollup, "", time.Second, time.Second)
+		require.NoError(t, err)
 
 		err = otherScanner.ProcessAssertionCreation(ctx, createdData.Leaf2.Id())
 		require.NoError(t, err)

--- a/chain-abstraction/sol-implementation/BUILD.bazel
+++ b/chain-abstraction/sol-implementation/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "assertion_chain.go",
         "edge_challenge_manager.go",
+        "transact.go",
         "types.go",
     ],
     importpath = "github.com/OffchainLabs/bold/chain-abstraction/sol-implementation",

--- a/chain-abstraction/sol-implementation/assertion_chain.go
+++ b/chain-abstraction/sol-implementation/assertion_chain.go
@@ -50,13 +50,6 @@ type ChainBackend interface {
 	ReceiptFetcher
 }
 
-// ChainCommitter defines a type of chain backend that supports
-// committing changes via a direct method, such as a simulated backend
-// for testing purposes.
-type ChainCommitter interface {
-	Commit() common.Hash
-}
-
 // ReceiptFetcher defines the ability to retrieve transactions receipts from the chain.
 type ReceiptFetcher interface {
 	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)

--- a/chain-abstraction/sol-implementation/assertion_chain.go
+++ b/chain-abstraction/sol-implementation/assertion_chain.go
@@ -80,9 +80,12 @@ func NewAssertionChain(
 	txOpts *bind.TransactOpts,
 	backend ChainBackend,
 ) (*AssertionChain, error) {
+	// We disable sending txs by default, as we will first estimate their gas before
+	// we commit them onchain through the transact method in this package.
+	opts := copyTxOpts(txOpts)
 	chain := &AssertionChain{
 		backend:    backend,
-		txOpts:     txOpts,
+		txOpts:     opts,
 		rollupAddr: rollupAddr,
 	}
 	coreBinding, err := rollupgen.NewRollupCore(
@@ -196,7 +199,6 @@ func (a *AssertionChain) createAndStakeOnAssertion(
 	if !parentAssertionCreationInfo.InboxMaxCount.IsUint64() {
 		return nil, errors.New("prev assertion creation info inbox max count not a uint64")
 	}
-	newOpts := copyTxOpts(a.txOpts)
 	if postState.GlobalState.Batch == 0 {
 		return nil, errors.New("assertion post state cannot have a batch count of 0, as only genesis can")
 	}
@@ -232,9 +234,9 @@ func (a *AssertionChain) createAndStakeOnAssertion(
 		return nil, errors.Wrapf(err, "could not fetch assertion with computed hash %#x", computedHash)
 	default:
 	}
-	receipt, err := transact(ctx, a.backend, func() (*types.Transaction, error) {
+	receipt, err := a.transact(ctx, a.backend, func(opts *bind.TransactOpts) (*types.Transaction, error) {
 		return stakeFn(
-			newOpts,
+			opts,
 			parentAssertionCreationInfo.RequiredStake,
 			rollupgen.AssertionInputs{
 				BeforeStateData: rollupgen.BeforeStateData{
@@ -326,9 +328,9 @@ func (a *AssertionChain) ConfirmAssertionByChallengeWinner(
 	if !prevCreationInfo.InboxMaxCount.IsUint64() {
 		return errors.New("assertion prev creation info inbox max count was not a uint64")
 	}
-	receipt, err := transact(ctx, a.backend, func() (*types.Transaction, error) {
+	receipt, err := a.transact(ctx, a.backend, func(opts *bind.TransactOpts) (*types.Transaction, error) {
 		return a.userLogic.RollupUserLogicTransactor.ConfirmAssertion(
-			copyTxOpts(a.txOpts),
+			opts,
 			b,
 			creationInfo.ParentAssertionHash,
 			creationInfo.AfterState,
@@ -657,67 +659,4 @@ func handleCreateAssertionError(err error, blockHash common.Hash) error {
 	default:
 		return err
 	}
-}
-
-// Runs a callback function meant to write to a chain backend, and if the
-// chain backend supports committing directly, we call the commit function before
-// returning. This function additionally waits for the transaction to complete and returns
-// an optional transaction receipt. It returns an error if the
-// transaction had a failed status on-chain, or if the execution of the callback
-// failed directly.
-func transact(ctx context.Context, backend ChainBackend, fn func() (*types.Transaction, error)) (*types.Receipt, error) {
-	tx, err := fn()
-	if err != nil {
-		return nil, err
-	}
-	if commiter, ok := backend.(ChainCommitter); ok {
-		commiter.Commit()
-	}
-	receipt, err := bind.WaitMined(ctx, backend, tx)
-	if err != nil {
-		return nil, err
-	}
-	if receipt.Status != types.ReceiptStatusSuccessful {
-		callMsg := ethereum.CallMsg{
-			From:       common.Address{},
-			To:         tx.To(),
-			Gas:        0,
-			GasPrice:   nil,
-			Value:      tx.Value(),
-			Data:       tx.Data(),
-			AccessList: tx.AccessList(),
-		}
-		if _, err := backend.CallContract(ctx, callMsg, nil); err != nil {
-			return nil, errors.Wrap(err, "failed transaction")
-		}
-	}
-	return receipt, nil
-}
-
-// copyTxOpts creates a deep copy of the given transaction options.
-func copyTxOpts(opts *bind.TransactOpts) *bind.TransactOpts {
-	copied := &bind.TransactOpts{
-		From:     opts.From,
-		Context:  opts.Context,
-		NoSend:   opts.NoSend,
-		Signer:   opts.Signer,
-		GasLimit: opts.GasLimit,
-	}
-
-	if opts.Nonce != nil {
-		copied.Nonce = new(big.Int).Set(opts.Nonce)
-	}
-	if opts.Value != nil {
-		copied.Value = new(big.Int).Set(opts.Value)
-	}
-	if opts.GasPrice != nil {
-		copied.GasPrice = new(big.Int).Set(opts.GasPrice)
-	}
-	if opts.GasFeeCap != nil {
-		copied.GasFeeCap = new(big.Int).Set(opts.GasFeeCap)
-	}
-	if opts.GasTipCap != nil {
-		copied.GasTipCap = new(big.Int).Set(opts.GasTipCap)
-	}
-	return copied
 }

--- a/chain-abstraction/sol-implementation/edge_challenge_manager.go
+++ b/chain-abstraction/sol-implementation/edge_challenge_manager.go
@@ -216,8 +216,8 @@ func (e *specEdge) Bisect(
 		return lower, upper, nil
 	}
 
-	_, err = transact(ctx, e.manager.backend, func() (*types.Transaction, error) {
-		return e.manager.writer.BisectEdge(e.manager.txOpts, e.id, prefixHistoryRoot, prefixProof)
+	_, err = e.manager.assertionChain.transact(ctx, e.manager.backend, func(opts *bind.TransactOpts) (*types.Transaction, error) {
+		return e.manager.writer.BisectEdge(opts, e.id, prefixHistoryRoot, prefixProof)
 	})
 	if err != nil {
 		return nil, nil, err
@@ -290,8 +290,8 @@ func (e *specEdge) ConfirmByTimer(ctx context.Context, ancestorIds []protocol.Ed
 	for i, r := range ancestorIds {
 		ancestors[i] = r.Hash
 	}
-	_, err = transact(ctx, e.manager.backend, func() (*types.Transaction, error) {
-		return e.manager.writer.ConfirmEdgeByTime(e.manager.txOpts, e.id, ancestors, challengeV2gen.ExecutionStateData{
+	_, err = e.manager.assertionChain.transact(ctx, e.manager.backend, func(opts *bind.TransactOpts) (*types.Transaction, error) {
+		return e.manager.writer.ConfirmEdgeByTime(opts, e.id, ancestors, challengeV2gen.ExecutionStateData{
 			ExecutionState: challengeV2gen.ExecutionState{
 				GlobalState:   challengeV2gen.GlobalState(assertionCreation.AfterState.GlobalState),
 				MachineStatus: assertionCreation.AfterState.MachineStatus,
@@ -322,8 +322,8 @@ func (e *specEdge) ConfirmByChildren(ctx context.Context) error {
 		return nil
 	}
 
-	_, err = transact(ctx, e.manager.backend, func() (*types.Transaction, error) {
-		return e.manager.writer.ConfirmEdgeByChildren(e.manager.txOpts, e.id)
+	_, err = e.manager.assertionChain.transact(ctx, e.manager.backend, func(opts *bind.TransactOpts) (*types.Transaction, error) {
+		return e.manager.writer.ConfirmEdgeByChildren(opts, e.id)
 	})
 	return err
 }
@@ -337,8 +337,8 @@ func (e *specEdge) ConfirmByClaim(ctx context.Context, claimId protocol.ClaimId)
 		return nil
 	}
 
-	_, err = transact(ctx, e.manager.backend, func() (*types.Transaction, error) {
-		return e.manager.writer.ConfirmEdgeByClaim(e.manager.txOpts, e.id, claimId)
+	_, err = e.manager.assertionChain.transact(ctx, e.manager.backend, func(opts *bind.TransactOpts) (*types.Transaction, error) {
+		return e.manager.writer.ConfirmEdgeByClaim(opts, e.id, claimId)
 	})
 	return err
 }
@@ -597,12 +597,12 @@ func (cm *specChallengeManager) ConfirmEdgeByOneStepProof(
 	for i, r := range postHistoryInclusionProof {
 		post[i] = r
 	}
-	_, err = transact(
+	_, err = cm.assertionChain.transact(
 		ctx,
 		cm.assertionChain.backend,
-		func() (*types.Transaction, error) {
+		func(opts *bind.TransactOpts) (*types.Transaction, error) {
 			return cm.writer.ConfirmEdgeByOneStepProof(
-				cm.assertionChain.txOpts,
+				opts,
 				tentativeWinnerId.Hash,
 				challengeV2gen.OneStepData{
 					BeforeHash: oneStepData.BeforeHash,
@@ -773,9 +773,9 @@ func (cm *specChallengeManager) AddBlockChallengeLevelZeroEdge(
 		PrefixProof:    startEndPrefixProof,
 		Proof:          blockEdgeProof,
 	}
-	receipt, err := transact(ctx, cm.backend, func() (*types.Transaction, error) {
+	receipt, err := cm.assertionChain.transact(ctx, cm.backend, func(opts *bind.TransactOpts) (*types.Transaction, error) {
 		return cm.writer.CreateLayerZeroEdge(
-			cm.txOpts,
+			opts,
 			args,
 		)
 	})
@@ -875,9 +875,9 @@ func (cm *specChallengeManager) AddSubChallengeLevelZeroEdge(
 	if err != nil {
 		return nil, err
 	}
-	_, err = transact(ctx, cm.backend, func() (*types.Transaction, error) {
+	_, err = cm.assertionChain.transact(ctx, cm.backend, func(opts *bind.TransactOpts) (*types.Transaction, error) {
 		return cm.writer.CreateLayerZeroEdge(
-			cm.txOpts,
+			opts,
 			challengeV2gen.CreateEdgeArgs{
 				Level:          subChalTyp.Uint8(),
 				EndHistoryRoot: endCommit.Merkle,

--- a/chain-abstraction/sol-implementation/transact.go
+++ b/chain-abstraction/sol-implementation/transact.go
@@ -1,0 +1,111 @@
+// Copyright 2023, Offchain Labs, Inc.
+// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+
+package solimpl
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/OffchainLabs/bold/containers"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/pkg/errors"
+)
+
+// Runs a callback function meant to write to a chain backend, and if the
+// chain backend supports committing directly, we call the commit function before
+// returning. This function additionally waits for the transaction to complete and returns
+// an optional transaction receipt. It returns an error if the
+// transaction had a failed status on-chain, or if the execution of the callback
+// failed directly.
+func (a *AssertionChain) transact(
+	ctx context.Context,
+	backend ChainBackend,
+	fn func(opts *bind.TransactOpts) (*types.Transaction, error),
+) (*types.Receipt, error) {
+	// We do not send the tx, but instead estimate gas first.
+	opts := copyTxOpts(a.txOpts)
+	opts.NoSend = true
+	tx, err := fn(opts)
+	if err != nil {
+		return nil, err
+	}
+	// Convert the transaction into a CallMsg.
+	msg := ethereum.CallMsg{
+		From:     opts.From,
+		To:       tx.To(),
+		Gas:      0, // Set to 0 to let the node decide
+		GasPrice: opts.GasPrice,
+		Value:    opts.Value,
+		Data:     tx.Data(),
+	}
+
+	// Estimate the gas required for the transaction. This will catch failures early
+	// without needing to pay for the transaction and waste funds.
+	gas, err := backend.EstimateGas(ctx, msg)
+	if err != nil {
+		return nil, errors.Wrapf(err, "gas estimation failed for tx with hash %s", containers.Trunc(tx.Hash().Bytes()))
+	}
+
+	// Now, we send the tx with the estimated gas.
+	opts.GasLimit = gas
+	opts.NoSend = false
+	tx, err = fn(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	if commiter, ok := backend.(ChainCommitter); ok {
+		commiter.Commit()
+	}
+	receipt, err := bind.WaitMined(ctx, backend, tx)
+	if err != nil {
+		return nil, err
+	}
+	if receipt.Status != types.ReceiptStatusSuccessful {
+		callMsg := ethereum.CallMsg{
+			From:       common.Address{},
+			To:         tx.To(),
+			Gas:        0,
+			GasPrice:   nil,
+			Value:      tx.Value(),
+			Data:       tx.Data(),
+			AccessList: tx.AccessList(),
+		}
+		if _, err := backend.CallContract(ctx, callMsg, nil); err != nil {
+			return nil, errors.Wrap(err, "failed transaction")
+		}
+	}
+	return receipt, nil
+}
+
+// copyTxOpts creates a deep copy of the given transaction options.
+func copyTxOpts(opts *bind.TransactOpts) *bind.TransactOpts {
+	copied := &bind.TransactOpts{
+		From:     opts.From,
+		Context:  opts.Context,
+		NoSend:   opts.NoSend,
+		Signer:   opts.Signer,
+		GasLimit: opts.GasLimit,
+	}
+
+	if opts.Nonce != nil {
+		copied.Nonce = new(big.Int).Set(opts.Nonce)
+	}
+	if opts.Value != nil {
+		copied.Value = new(big.Int).Set(opts.Value)
+	}
+	if opts.GasPrice != nil {
+		copied.GasPrice = new(big.Int).Set(opts.GasPrice)
+	}
+	if opts.GasFeeCap != nil {
+		copied.GasFeeCap = new(big.Int).Set(opts.GasFeeCap)
+	}
+	if opts.GasTipCap != nil {
+		copied.GasTipCap = new(big.Int).Set(opts.GasTipCap)
+	}
+	return copied
+}

--- a/chain-abstraction/sol-implementation/transact.go
+++ b/chain-abstraction/sol-implementation/transact.go
@@ -5,7 +5,6 @@ package solimpl
 
 import (
 	"context"
-	"fmt"
 	"math/big"
 
 	"github.com/OffchainLabs/bold/containers"
@@ -39,7 +38,7 @@ func (a *AssertionChain) transact(
 	opts.NoSend = true
 	tx, err := fn(opts)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "test execution of tx failed before sending payable tx")
 	}
 	// Convert the transaction into a CallMsg.
 	msg := ethereum.CallMsg{
@@ -57,8 +56,6 @@ func (a *AssertionChain) transact(
 	if err != nil {
 		return nil, errors.Wrapf(err, "gas estimation failed for tx with hash %s", containers.Trunc(tx.Hash().Bytes()))
 	}
-
-	fmt.Printf("Estimate gas %d\n", gas)
 
 	// Now, we send the tx with the estimated gas.
 	opts.GasLimit = gas

--- a/chain-abstraction/sol-implementation/transact.go
+++ b/chain-abstraction/sol-implementation/transact.go
@@ -5,6 +5,7 @@ package solimpl
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 
 	"github.com/OffchainLabs/bold/containers"
@@ -14,6 +15,13 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/pkg/errors"
 )
+
+// ChainCommitter defines a type of chain backend that supports
+// committing changes via a direct method, such as a simulated backend
+// for testing purposes.
+type ChainCommitter interface {
+	Commit() common.Hash
+}
 
 // Runs a callback function meant to write to a chain backend, and if the
 // chain backend supports committing directly, we call the commit function before
@@ -49,6 +57,8 @@ func (a *AssertionChain) transact(
 	if err != nil {
 		return nil, errors.Wrapf(err, "gas estimation failed for tx with hash %s", containers.Trunc(tx.Hash().Bytes()))
 	}
+
+	fmt.Printf("Estimate gas %d\n", gas)
 
 	// Now, we send the tx with the estimated gas.
 	opts.GasLimit = gas

--- a/challenge-manager/chain-watcher/watcher.go
+++ b/challenge-manager/chain-watcher/watcher.go
@@ -109,7 +109,10 @@ func New(
 	interval time.Duration,
 	numBigStepLevels uint8,
 	validatorName string,
-) *Watcher {
+) (*Watcher, error) {
+	if interval == 0 {
+		return nil, errors.New("chain watcher polling interval must be greater than 0")
+	}
 	return &Watcher{
 		chain:              chain,
 		edgeManager:        edgeManager,
@@ -119,7 +122,7 @@ func New(
 		histChecker:        histChecker,
 		numBigStepLevels:   numBigStepLevels,
 		validatorName:      validatorName,
-	}
+	}, nil
 }
 
 // HonestBlockChallengeRootEdge gets the honest block challenge root edge for a given challenge

--- a/challenge-manager/edge-tracker/tracker.go
+++ b/challenge-manager/edge-tracker/tracker.go
@@ -149,6 +149,9 @@ func New(
 	for _, o := range opts {
 		o(tr)
 	}
+	if tr.actInterval == 0 {
+		return nil, errors.New("edge tracker act interval must be greater than 0")
+	}
 	fsm, err := newEdgeTrackerFsm(
 		EdgeStarted,
 		tr.fsmOpts...,

--- a/challenge-manager/manager.go
+++ b/challenge-manager/manager.go
@@ -199,14 +199,22 @@ func New(
 	m.rollupFilterer = rollupFilterer
 	m.chalManagerAddr = chalManagerAddr
 	m.chalManager = chalManagerFilterer
-	m.watcher = watcher.New(m.chain, m, m.stateManager, backend, m.chainWatcherInterval, numBigStepLevels, m.name)
-	m.poster = assertions.NewPoster(
+	watcher, err := watcher.New(m.chain, m, m.stateManager, backend, m.chainWatcherInterval, numBigStepLevels, m.name)
+	if err != nil {
+		return nil, err
+	}
+	m.watcher = watcher
+	poster, err := assertions.NewPoster(
 		m.chain,
 		m.stateManager,
 		m.name,
 		m.assertionPostingInterval,
 	)
-	m.scanner = assertions.NewScanner(
+	if err != nil {
+		return nil, err
+	}
+	m.poster = poster
+	scanner, err := assertions.NewScanner(
 		m.chain,
 		m.stateManager,
 		m.backend,
@@ -216,6 +224,10 @@ func New(
 		m.assertionScanningInterval,
 		m.assertionConfirmingInterval,
 	)
+	if err != nil {
+		return nil, err
+	}
+	m.scanner = scanner
 
 	if m.apiAddr != "" && m.client == nil {
 		return nil, errors.New("go-ethereum RPC client required to enable API service")

--- a/challenge-manager/manager_test.go
+++ b/challenge-manager/manager_test.go
@@ -315,7 +315,8 @@ func setupEdgeTrackersForBisection(
 	require.NoError(t, err)
 	numBigStepLevels := numBigStepLevelsRaw
 
-	honestWatcher := watcher.New(honestValidator.chain, honestValidator, honestValidator.stateManager, createdData.Backend, time.Second, numBigStepLevels, "alice")
+	honestWatcher, err := watcher.New(honestValidator.chain, honestValidator, honestValidator.stateManager, createdData.Backend, time.Second, numBigStepLevels, "alice")
+	require.NoError(t, err)
 	honestValidator.watcher = honestWatcher
 	assertionInfo := &edgetracker.AssociatedAssertionMetadata{
 		FromBatch:      0,
@@ -335,7 +336,8 @@ func setupEdgeTrackersForBisection(
 	)
 	require.NoError(t, err)
 
-	evilWatcher := watcher.New(evilValidator.chain, evilValidator, evilValidator.stateManager, createdData.Backend, time.Second, numBigStepLevels, "alice")
+	evilWatcher, err := watcher.New(evilValidator.chain, evilValidator, evilValidator.stateManager, createdData.Backend, time.Second, numBigStepLevels, "alice")
+	require.NoError(t, err)
 	evilValidator.watcher = evilWatcher
 	tracker2, err := edgetracker.New(
 		ctx,

--- a/testing/endtoend/basic_local_test.go
+++ b/testing/endtoend/basic_local_test.go
@@ -201,8 +201,14 @@ func testChallengeProtocol_AliceAndBob(t *testing.T, be backend.Backend, scenari
 		}
 
 		// Post assertions.
-		alicePoster := assertions.NewPoster(aChain, scenario.AliceStateManager, "alice", time.Hour)
-		bobPoster := assertions.NewPoster(bChain, scenario.BobStateManager, "bob", time.Hour)
+		alicePoster, err := assertions.NewPoster(aChain, scenario.AliceStateManager, "alice", time.Hour)
+		if err != nil {
+			t.Fatal(err)
+		}
+		bobPoster, err := assertions.NewPoster(bChain, scenario.BobStateManager, "bob", time.Hour)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		aliceLeaf, err := alicePoster.PostAssertionAndNewStake(ctx)
 		if err != nil {
@@ -214,14 +220,20 @@ func testChallengeProtocol_AliceAndBob(t *testing.T, be backend.Backend, scenari
 		}
 
 		// Scan for created assertions.
-		aliceScanner := assertions.NewScanner(aChain, scenario.AliceStateManager, be.Client(), a, rollup, "alice", time.Hour, time.Second*10)
-		bobScanner := assertions.NewScanner(bChain, scenario.BobStateManager, be.Client(), b, rollup, "bob", time.Hour, time.Second*10)
+		aliceScanner, err := assertions.NewScanner(aChain, scenario.AliceStateManager, be.Client(), a, rollup, "alice", time.Hour, time.Second*10)
+		if err != nil {
+			t.Fatal(err)
+		}
+		bobScanner, err := assertions.NewScanner(bChain, scenario.BobStateManager, be.Client(), b, rollup, "bob", time.Hour, time.Second*10)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		if err := aliceScanner.ProcessAssertionCreation(ctx, aliceLeaf.Id()); err != nil {
-			panic(err)
+			t.Fatal(err)
 		}
 		if err := bobScanner.ProcessAssertionCreation(ctx, bobLeaf.Id()); err != nil {
-			panic(err)
+			t.Fatal(err)
 		}
 
 		a.Start(ctx)
@@ -263,14 +275,18 @@ func testSyncBobStopsCharlieJoins(t *testing.T, be backend.Backend, s *Challenge
 		bob, err := validator.New(bobCtx, bChain, be.Client(), s.BobStateManager, rollup, validator.WithAddress(be.Bob().From), validator.WithName("bob"), validator.WithMode(types.MakeMode), validator.WithEdgeTrackerWakeInterval(100*time.Millisecond))
 		require.NoError(t, err)
 
-		alicePoster := assertions.NewPoster(aChain, s.AliceStateManager, "alice", time.Hour)
-		bobPoster := assertions.NewPoster(bChain, s.BobStateManager, "bob", time.Hour)
+		alicePoster, err := assertions.NewPoster(aChain, s.AliceStateManager, "alice", time.Hour)
+		require.NoError(t, err)
+		bobPoster, err := assertions.NewPoster(bChain, s.BobStateManager, "bob", time.Hour)
+		require.NoError(t, err)
 		aliceLeaf, err := alicePoster.PostAssertionAndNewStake(ctx)
 		require.NoError(t, err)
 		bobLeaf, err := bobPoster.PostAssertionAndNewStake(bobCtx)
 		require.NoError(t, err)
-		aliceScanner := assertions.NewScanner(aChain, s.AliceStateManager, be.Client(), alice, rollup, "alice", time.Hour, time.Second*10)
-		bobScanner := assertions.NewScanner(bChain, s.BobStateManager, be.Client(), bob, rollup, "bob", time.Hour, time.Second*10)
+		aliceScanner, err := assertions.NewScanner(aChain, s.AliceStateManager, be.Client(), alice, rollup, "alice", time.Hour, time.Second*10)
+		require.NoError(t, err)
+		bobScanner, err := assertions.NewScanner(bChain, s.BobStateManager, be.Client(), bob, rollup, "bob", time.Hour, time.Second*10)
+		require.NoError(t, err)
 		require.NoError(t, aliceScanner.ProcessAssertionCreation(ctx, aliceLeaf.Id()))
 		require.NoError(t, bobScanner.ProcessAssertionCreation(bobCtx, bobLeaf.Id()))
 


### PR DESCRIPTION
We should be estimating gas before sending txs through our chain abstraction, as this will catch errors early without us having to spend the funds to do so. This PR also adds protections for places where we might be using a time.Duration of 0, which would cause a runtime panic.