### PR TITLE
Include a TrackedContractBackend to Gather L1 Usage Metrics

### DIFF
--- a/chain-abstraction/BUILD.bazel
+++ b/chain-abstraction/BUILD.bazel
@@ -13,7 +13,9 @@ go_library(
         "//solgen/go/challengegen",
         "//solgen/go/rollupgen",
         "//state-commitments/history",
+        "@com_github_ethereum_go_ethereum//accounts/abi/bind",
         "@com_github_ethereum_go_ethereum//common",
+        "@com_github_ethereum_go_ethereum//core/types",
         "@com_github_ethereum_go_ethereum//crypto",
     ],
 )

--- a/chain-abstraction/interfaces.go
+++ b/chain-abstraction/interfaces.go
@@ -13,9 +13,22 @@ import (
 	"github.com/OffchainLabs/bold/containers/option"
 	"github.com/OffchainLabs/bold/solgen/go/rollupgen"
 	commitments "github.com/OffchainLabs/bold/state-commitments/history"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 )
+
+// ChainBackend to interact with the underlying blockchain.
+type ChainBackend interface {
+	bind.ContractBackend
+	ReceiptFetcher
+}
+
+// ReceiptFetcher defines the ability to retrieve transactions receipts from the chain.
+type ReceiptFetcher interface {
+	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
+}
 
 // LayerZeroHeights for edges configured as parameters in the challenge manager contract.
 type LayerZeroHeights struct {
@@ -81,6 +94,7 @@ type AssertionChain interface {
 	// Read-only methods.
 	IsStaked(ctx context.Context) (bool, error)
 	GetAssertion(ctx context.Context, id AssertionHash) (Assertion, error)
+	Backend() ChainBackend
 	AssertionStatus(
 		ctx context.Context,
 		assertionHash AssertionHash,

--- a/chain-abstraction/sol-implementation/BUILD.bazel
+++ b/chain-abstraction/sol-implementation/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "assertion_chain.go",
         "edge_challenge_manager.go",
+        "tracked_contract_backend.go",
         "types.go",
     ],
     importpath = "github.com/OffchainLabs/bold/chain-abstraction/sol-implementation",
@@ -32,6 +33,7 @@ go_test(
         "assertion_chain_helper_test.go",
         "assertion_chain_test.go",
         "edge_challenge_manager_test.go",
+        "tracked_contract_backend_test.go",
         "types_test.go",
     ],
     embed = [":sol-implementation"],

--- a/chain-abstraction/sol-implementation/assertion_chain_helper_test.go
+++ b/chain-abstraction/sol-implementation/assertion_chain_helper_test.go
@@ -1,5 +1,7 @@
 package solimpl
 
-func (a *AssertionChain) SetBackend(b ChainBackend) {
+import protocol "github.com/OffchainLabs/bold/chain-abstraction"
+
+func (a *AssertionChain) SetBackend(b protocol.ChainBackend) {
 	a.backend = b
 }

--- a/chain-abstraction/sol-implementation/edge_challenge_manager.go
+++ b/chain-abstraction/sol-implementation/edge_challenge_manager.go
@@ -391,7 +391,7 @@ func (e *specEdge) TopLevelClaimHeight(ctx context.Context) (protocol.OriginHeig
 // Wrapper around the challenge manager contract with developer-friendly methods.
 type specChallengeManager struct {
 	addr           common.Address
-	backend        ChainBackend
+	backend        protocol.ChainBackend
 	assertionChain *AssertionChain
 	txOpts         *bind.TransactOpts
 	caller         *challengeV2gen.EdgeChallengeManagerCaller
@@ -405,7 +405,7 @@ func NewSpecChallengeManager(
 	_ context.Context,
 	addr common.Address,
 	assertionChain *AssertionChain,
-	backend ChainBackend,
+	backend protocol.ChainBackend,
 	txOpts *bind.TransactOpts,
 ) (protocol.SpecChallengeManager, error) {
 	managerBinding, err := challengeV2gen.NewEdgeChallengeManager(addr, backend)

--- a/chain-abstraction/sol-implementation/tracked_contract_backend.go
+++ b/chain-abstraction/sol-implementation/tracked_contract_backend.go
@@ -1,0 +1,106 @@
+// Copyright 2023, Offchain Labs, Inc.
+// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+
+package solimpl
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"sort"
+	"sync"
+
+	protocol "github.com/OffchainLabs/bold/chain-abstraction"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// TrackedContractBackend implements a wrapper around a chain backend interface
+// which can keep track of the number of calls and transactions made per
+// method to a contract along with gas costs for transactions. These can then be
+// printed out to a destination for analysis.
+type TrackedContractBackend struct {
+	protocol.ChainBackend
+	metrics map[string]*MethodMetrics // method hash -> metrics
+	mu      sync.RWMutex
+}
+
+type MethodMetrics struct {
+	Calls    int       // Total number of calls to the method.
+	Txs      int       // Total number of transactions to the method.
+	GasCosts []big.Int // Gas costs for each tx.
+}
+
+func NewTrackedContractBackend(backend protocol.ChainBackend) *TrackedContractBackend {
+	return &TrackedContractBackend{
+		ChainBackend: backend,
+		metrics:      make(map[string]*MethodMetrics),
+	}
+}
+
+func (t *TrackedContractBackend) CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+	data := call.Data
+	if len(data) >= 4 { // if there's a method selector
+		methodHash := fmt.Sprintf("%#x", data[:4]) // first 4 bytes are method selector
+		t.mu.Lock()
+		metric, ok := t.metrics[methodHash]
+		if !ok {
+			metric = &MethodMetrics{}
+			t.metrics[methodHash] = metric
+		}
+		metric.Calls++
+		// Assuming gas cost for call can be added here if needed
+		t.mu.Unlock()
+	}
+	return t.ChainBackend.CallContract(ctx, call, blockNumber)
+}
+
+func (t *TrackedContractBackend) SendTransaction(ctx context.Context, tx *types.Transaction) error {
+	if tx != nil && len(tx.Data()) >= 4 {
+		methodHash := fmt.Sprintf("%#x", tx.Data()[:4])
+		t.mu.Lock()
+		metric, ok := t.metrics[methodHash]
+		if !ok {
+			metric = &MethodMetrics{}
+			t.metrics[methodHash] = metric
+		}
+		metric.Txs++
+		gasCost := new(big.Int).Mul(tx.GasPrice(), new(big.Int).SetUint64(tx.Gas()))
+		metric.GasCosts = append(metric.GasCosts, *gasCost)
+		t.mu.Unlock()
+	}
+	return t.ChainBackend.SendTransaction(ctx, tx)
+}
+
+// Computes a median of big integers (gas costs)
+func median(gasCosts []big.Int) *big.Int {
+	if len(gasCosts) == 0 {
+		return nil
+	}
+	sorted := make([]big.Int, len(gasCosts))
+	copy(sorted, gasCosts)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Cmp(&sorted[j]) < 0
+	})
+	mid := len(sorted) / 2
+	if len(sorted)%2 == 0 {
+		return new(big.Int).Add(&sorted[mid-1], &sorted[mid]).Div(&sorted[mid], big.NewInt(2))
+	}
+	return &sorted[mid]
+}
+
+func (t *TrackedContractBackend) PrintMetrics() {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	for methodHash, metrics := range t.metrics {
+		fmt.Printf("Method: %s\n", methodHash)
+		fmt.Printf("Calls: %d\n", metrics.Calls)
+		fmt.Printf("Transactions: %d\n", metrics.Txs)
+		if med := median(metrics.GasCosts); med != nil {
+			fmt.Printf("Median Gas Cost: %s\n", med.String())
+		} else {
+			fmt.Println("Median Gas Cost: N/A")
+		}
+		fmt.Println("-----------")
+	}
+}

--- a/chain-abstraction/sol-implementation/tracked_contract_backend_test.go
+++ b/chain-abstraction/sol-implementation/tracked_contract_backend_test.go
@@ -1,0 +1,128 @@
+package solimpl
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrackedContractBackend(t *testing.T) {
+	backend := NewTrackedContractBackend(&MockContractBackend{})
+
+	t.Run("CallContract", func(t *testing.T) {
+		data := []byte("1234mockdata1283918231923")
+		call := ethereum.CallMsg{Data: data}
+		_, err := backend.CallContract(context.Background(), call, nil)
+		require.NoError(t, err)
+
+		key := fmt.Sprintf("%#x", data[:4])
+		metric, ok := backend.metrics[key]
+		require.True(t, ok)
+		require.Equal(t, 1, metric.Calls)
+	})
+
+	t.Run("SendTransaction", func(t *testing.T) {
+		data := []byte("1234mocktx1283918231923")
+		tx := types.NewTransaction(1, common.HexToAddress("0x123456789"), big.NewInt(1), 21000, big.NewInt(1), data)
+		err := backend.SendTransaction(context.Background(), tx)
+		require.NoError(t, err)
+
+		key := fmt.Sprintf("%#x", data[:4])
+		metric, ok := backend.metrics[key]
+		require.True(t, ok)
+		require.Equal(t, 1, metric.Txs)
+		require.Equal(t, big.NewInt(21000), &metric.GasCosts[0])
+	})
+}
+
+func Test_median(t *testing.T) {
+	t.Run("Empty slice", func(t *testing.T) {
+		var gasCosts []big.Int
+		med := median(gasCosts)
+		require.Equal(t, true, med == nil)
+	})
+
+	t.Run("Single value", func(t *testing.T) {
+		gasCosts := []big.Int{*big.NewInt(5)}
+		med := median(gasCosts)
+		require.Equal(t, big.NewInt(5), med)
+	})
+
+	t.Run("Even number of values", func(t *testing.T) {
+		gasCosts := []big.Int{*big.NewInt(5), *big.NewInt(15)}
+		med := median(gasCosts)
+		require.Equal(t, big.NewInt(10), med)
+	})
+
+	t.Run("Odd number of values", func(t *testing.T) {
+		gasCosts := []big.Int{*big.NewInt(5), *big.NewInt(15), *big.NewInt(25)}
+		med := median(gasCosts)
+		require.Equal(t, big.NewInt(15), med)
+	})
+
+	t.Run("Unsorted values", func(t *testing.T) {
+		gasCosts := []big.Int{*big.NewInt(25), *big.NewInt(5), *big.NewInt(15)}
+		med := median(gasCosts)
+		require.Equal(t, big.NewInt(15), med)
+	})
+}
+
+type MockContractBackend struct{}
+
+func (m *MockContractBackend) CodeAt(ctx context.Context, contract common.Address, blockNumber *big.Int) ([]byte, error) {
+	return nil, nil
+}
+
+func (m *MockContractBackend) CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+	return nil, nil
+}
+
+func (m *MockContractBackend) PendingCodeAt(ctx context.Context, contract common.Address) ([]byte, error) {
+	return nil, nil
+}
+
+func (m *MockContractBackend) PendingCallContract(ctx context.Context, call ethereum.CallMsg) ([]byte, error) {
+	return nil, nil
+}
+
+func (m *MockContractBackend) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
+	return nil, nil
+}
+
+func (m *MockContractBackend) PendingNonceAt(ctx context.Context, account common.Address) (uint64, error) {
+	return 0, nil
+}
+
+func (m *MockContractBackend) SuggestGasPrice(ctx context.Context) (*big.Int, error) {
+	return big.NewInt(1), nil
+}
+
+func (m *MockContractBackend) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
+	return big.NewInt(1), nil
+}
+
+func (m *MockContractBackend) EstimateGas(ctx context.Context, call ethereum.CallMsg) (gas uint64, err error) {
+	return 0, nil
+}
+
+func (m *MockContractBackend) SendTransaction(ctx context.Context, tx *types.Transaction) error {
+	return nil
+}
+
+func (m *MockContractBackend) FilterLogs(ctx context.Context, query ethereum.FilterQuery) ([]types.Log, error) {
+	return nil, nil
+}
+
+func (m *MockContractBackend) SubscribeFilterLogs(ctx context.Context, query ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error) {
+	return nil, nil
+}
+
+func (m *MockContractBackend) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
+	return nil, nil
+}

--- a/chain-abstraction/sol-implementation/tracked_contract_backend_test.go
+++ b/chain-abstraction/sol-implementation/tracked_contract_backend_test.go
@@ -54,10 +54,10 @@ func Test_median(t *testing.T) {
 		require.Equal(t, big.NewInt(5), med)
 	})
 
-	t.Run("Even number of values", func(t *testing.T) {
+	t.Run("Two values takes mean", func(t *testing.T) {
 		gasCosts := []big.Int{*big.NewInt(5), *big.NewInt(15)}
 		med := median(gasCosts)
-		require.Equal(t, big.NewInt(10), med)
+		require.Equal(t, big.NewInt(7), med)
 	})
 
 	t.Run("Odd number of values", func(t *testing.T) {

--- a/testing/endtoend/basic_local_test.go
+++ b/testing/endtoend/basic_local_test.go
@@ -239,7 +239,7 @@ func testChallengeProtocol_AliceAndBob(t *testing.T, be backend.Backend, scenari
 			t.Fatal(err)
 		}
 
-		trackedBacked, ok := aChain.Backend().(*solimpl.TrackedContractBackend)
+		trackedBackend, ok := aChain.Backend().(*solimpl.TrackedContractBackend)
 		if !ok {
 			t.Fatal("Not a tracked contract backend")
 		}

--- a/testing/endtoend/basic_local_test.go
+++ b/testing/endtoend/basic_local_test.go
@@ -218,10 +218,10 @@ func testChallengeProtocol_AliceAndBob(t *testing.T, be backend.Backend, scenari
 		bobScanner := assertions.NewScanner(bChain, scenario.BobStateManager, be.Client(), b, rollup, "bob", time.Hour, time.Second*10)
 
 		if err := aliceScanner.ProcessAssertionCreation(ctx, aliceLeaf.Id()); err != nil {
-			panic(err)
+			t.Fatal(err)
 		}
 		if err := bobScanner.ProcessAssertionCreation(ctx, bobLeaf.Id()); err != nil {
-			panic(err)
+			t.Fatal(err)
 		}
 
 		a.Start(ctx)
@@ -238,6 +238,13 @@ func testChallengeProtocol_AliceAndBob(t *testing.T, be backend.Backend, scenari
 		if err := g.Wait(); err != nil {
 			t.Fatal(err)
 		}
+
+		trackedBacked, ok := aChain.Backend().(*solimpl.TrackedContractBackend)
+		if !ok {
+			t.Fatal("Not a tracked contract backend")
+		}
+		t.Log("Printing Alice's ethclient metrics at the end of a challenge")
+		trackedBackend.PrintMetrics()
 	})
 }
 
@@ -318,6 +325,7 @@ func setupValidator(
 		rollup,
 		txOpts,
 		be.Client(),
+		solimpl.WithTrackedContractBackend(),
 	)
 	if err != nil {
 		return nil, nil, err

--- a/testing/mocks/mocks.go
+++ b/testing/mocks/mocks.go
@@ -355,6 +355,10 @@ type MockProtocol struct {
 }
 
 // Read-only methods.
+func (m *MockProtocol) Backend() protocol.ChainBackend {
+	args := m.Called()
+	return args.Get(0).(protocol.ChainBackend)
+}
 func (m *MockProtocol) NumAssertions(ctx context.Context) (uint64, error) {
 	args := m.Called(ctx)
 	return args.Get(0).(uint64), args.Error(1)


### PR DESCRIPTION
This PR includes a `TrackedContractBackend` type which wraps around `ContractBackend` and can keep track of number of eth calls and txs by method along with gas used per call. This is helpful for optimizing how much we need data from L1 and figuring out where we are making unnecessary calls. At the end of an e2e test, we print out the metrics from the honest validator.

It can be enabled by starting an assertion chain with `WithTrackedContractBackend()` as an option.

Methods with the largest number of calls, with the current config values that trigger edge actions at very fast intervals (250 milliseconds)

- GetEdge (197,858)
- GetAssertion (68,259)
- ConfirmedRival (15,325)
- NumBigStepLevel (10,508)
- ChallengePeriodBlocks (15,291)
- CalculateMutualId (25,832)
- GetPrevAssertionHash (15,855)
- ChallengeManager (15,952)
- HasRival (2,047)

Some of these can be computed once for a challenge, or can be done completely offline, such as the mutual id computation. We also need to audit ways of reducing our calls to GetEdge when we really don't need up to date info.