### PR TITLE
Revamp Assertion Service for Production

### DIFF
--- a/assertions/BUILD.bazel
+++ b/assertions/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//chain-abstraction/sol-implementation",
         "//challenge-manager/types",
         "//containers",
+        "//containers/threadsafe",
         "//layer2-state-provider",
         "//runtime",
         "//solgen/go/rollupgen",

--- a/assertions/BUILD.bazel
+++ b/assertions/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
         "//challenge-manager",
         "//challenge-manager/types",
         "//containers/option",
+        "//containers/threadsafe",
         "//layer2-state-provider",
         "//solgen/go/rollupgen",
         "//testing/mocks",

--- a/assertions/BUILD.bazel
+++ b/assertions/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
     name = "assertions_test",
     srcs = [
         "poster_test.go",
+        "scanner_internals_test.go",
         "scanner_test.go",
     ],
     embed = [":assertions"],
@@ -36,11 +37,14 @@ go_test(
         "//challenge-manager",
         "//challenge-manager/types",
         "//containers/option",
+        "//layer2-state-provider",
         "//solgen/go/rollupgen",
         "//testing/mocks",
         "//testing/setup:setup_lib",
         "@com_github_ethereum_go_ethereum//common",
         "@com_github_pkg_errors//:errors",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//mock",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/assertions/poster.go
+++ b/assertions/poster.go
@@ -56,7 +56,7 @@ func (s *Manager) PostAssertion(ctx context.Context) (protocol.Assertion, error)
 	}
 	// If the validator is already staked, we post an assertion and move existing stake to it.
 	if staked {
-		assertion, err := s.postAssertionBasedOnParent(
+		assertion, err := s.PostAssertionBasedOnParent(
 			ctx, parentAssertionCreationInfo, s.chain.StakeOnNewAssertion,
 		)
 		if err != nil {
@@ -66,7 +66,7 @@ func (s *Manager) PostAssertion(ctx context.Context) (protocol.Assertion, error)
 		return assertion, nil
 	}
 	// Otherwise, we post a new assertion and place a new stake on it.
-	assertion, err := s.postAssertionBasedOnParent(
+	assertion, err := s.PostAssertionBasedOnParent(
 		ctx, parentAssertionCreationInfo, s.chain.NewStakeOnNewAssertion,
 	)
 	if err != nil {
@@ -77,7 +77,7 @@ func (s *Manager) PostAssertion(ctx context.Context) (protocol.Assertion, error)
 }
 
 // Posts a new assertion onchain based on a parent assertion we agree with.
-func (s *Manager) postAssertionBasedOnParent(
+func (s *Manager) PostAssertionBasedOnParent(
 	ctx context.Context,
 	parentCreationInfo *protocol.AssertionCreatedInfo,
 	submitFn func(

--- a/assertions/poster.go
+++ b/assertions/poster.go
@@ -17,7 +17,9 @@ import (
 
 func (s *Manager) postAssertionRoutine(ctx context.Context) {
 	if _, err := s.PostAssertion(ctx); err != nil {
-		srvlog.Error("Could not submit latest assertion to L1", log.Ctx{"err": err})
+		if !errors.Is(err, solimpl.ErrAlreadyExists) {
+			srvlog.Error("Could not submit latest assertion to L1", log.Ctx{"err": err})
+		}
 	}
 	ticker := time.NewTicker(s.postInterval)
 	defer ticker.Stop()
@@ -25,7 +27,9 @@ func (s *Manager) postAssertionRoutine(ctx context.Context) {
 		select {
 		case <-ticker.C:
 			if _, err := s.PostAssertion(ctx); err != nil {
-				srvlog.Error("Could not submit latest assertion to L1", log.Ctx{"err": err})
+				if !errors.Is(err, solimpl.ErrAlreadyExists) {
+					srvlog.Error("Could not submit latest assertion to L1", log.Ctx{"err": err})
+				}
 			}
 		case <-ctx.Done():
 			return
@@ -33,36 +37,8 @@ func (s *Manager) postAssertionRoutine(ctx context.Context) {
 	}
 }
 
-// PostAssertion differs depending on whether the validator is currently staked.
+// PostAssertion differs depending on whether or not the validator is currently staked.
 func (s *Manager) PostAssertion(ctx context.Context) (protocol.Assertion, error) {
-	staked, err := s.chain.IsStaked(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if staked {
-		return s.PostAssertionAndMoveStake(ctx)
-	}
-	return s.PostAssertionAndNewStake(ctx)
-}
-
-// PostAssertionAndNewStake posts the latest assertion and adds a new stake on it.
-func (s *Manager) PostAssertionAndNewStake(ctx context.Context) (protocol.Assertion, error) {
-	return s.postAssertionImpl(ctx, s.chain.NewStakeOnNewAssertion)
-}
-
-// PostAssertionAndMoveStake posts the latest assertion and moves an existing stake to it.
-func (s *Manager) PostAssertionAndMoveStake(ctx context.Context) (protocol.Assertion, error) {
-	return s.postAssertionImpl(ctx, s.chain.StakeOnNewAssertion)
-}
-
-func (s *Manager) postAssertionImpl(
-	ctx context.Context,
-	submitFn func(
-		ctx context.Context,
-		parentCreationInfo *protocol.AssertionCreatedInfo,
-		newState *protocol.ExecutionState,
-	) (protocol.Assertion, error),
-) (protocol.Assertion, error) {
 	// Ensure that we only build on a valid parent from this validator's perspective.
 	// the validator should also have ready access to historical commitments to make sure it can select
 	// the valid parent based on its commitment state root.
@@ -74,20 +50,61 @@ func (s *Manager) postAssertionImpl(
 	if err != nil {
 		return nil, err
 	}
-	if !parentAssertionCreationInfo.InboxMaxCount.IsUint64() {
+	staked, err := s.chain.IsStaked(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// If the validator is already staked, we post an assertion and move existing stake to it.
+	if staked {
+		assertion, err := s.postAssertionBasedOnParent(
+			ctx, parentAssertionCreationInfo, s.chain.StakeOnNewAssertion,
+		)
+		if err != nil {
+			return nil, err
+		}
+		s.submittedAssertions.Insert(assertion.Id().Hash)
+		return assertion, nil
+	}
+	// Otherwise, we post a new assertion and place a new stake on it.
+	assertion, err := s.postAssertionBasedOnParent(
+		ctx, parentAssertionCreationInfo, s.chain.NewStakeOnNewAssertion,
+	)
+	if err != nil {
+		return nil, err
+	}
+	s.submittedAssertions.Insert(assertion.Id().Hash)
+	return assertion, nil
+}
+
+// Posts a new assertion onchain based on a parent assertion we agree with.
+func (s *Manager) postAssertionBasedOnParent(
+	ctx context.Context,
+	parentCreationInfo *protocol.AssertionCreatedInfo,
+	submitFn func(
+		ctx context.Context,
+		parentCreationInfo *protocol.AssertionCreatedInfo,
+		newState *protocol.ExecutionState,
+	) (protocol.Assertion, error),
+) (protocol.Assertion, error) {
+	if !parentCreationInfo.InboxMaxCount.IsUint64() {
 		return nil, errors.New("inbox max count not a uint64")
 	}
 	// The parent assertion tells us what the next posted assertion's batch should be.
 	// We read this value and use it to compute the required execution state we must post.
-	batchCount := parentAssertionCreationInfo.InboxMaxCount.Uint64()
+	batchCount := parentCreationInfo.InboxMaxCount.Uint64()
 	newState, err := s.stateManager.ExecutionStateAfterBatchCount(ctx, batchCount)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not get execution state at message count %d", batchCount)
 	}
-	srvlog.Info("Required batch for assertion and retrieved state", log.Ctx{"batch": batchCount, "newState": fmt.Sprintf("%+v", newState)})
+	srvlog.Info(
+		"Posting assertion with retrieved state", log.Ctx{
+			"batchCount": batchCount,
+			"newState":   fmt.Sprintf("%+v", newState),
+		},
+	)
 	assertion, err := submitFn(
 		ctx,
-		parentAssertionCreationInfo,
+		parentCreationInfo,
 		newState,
 	)
 	switch {

--- a/assertions/poster.go
+++ b/assertions/poster.go
@@ -56,11 +56,11 @@ func (s *Manager) PostAssertion(ctx context.Context) (protocol.Assertion, error)
 	}
 	// If the validator is already staked, we post an assertion and move existing stake to it.
 	if staked {
-		assertion, err := s.PostAssertionBasedOnParent(
+		assertion, postErr := s.PostAssertionBasedOnParent(
 			ctx, parentAssertionCreationInfo, s.chain.StakeOnNewAssertion,
 		)
-		if err != nil {
-			return nil, err
+		if postErr != nil {
+			return nil, postErr
 		}
 		s.submittedAssertions.Insert(assertion.Id().Hash)
 		return assertion, nil

--- a/assertions/poster_test.go
+++ b/assertions/poster_test.go
@@ -11,6 +11,7 @@ import (
 
 	protocol "github.com/OffchainLabs/bold/chain-abstraction"
 	"github.com/OffchainLabs/bold/containers/option"
+	"github.com/OffchainLabs/bold/containers/threadsafe"
 	"github.com/OffchainLabs/bold/solgen/go/rollupgen"
 	"github.com/OffchainLabs/bold/testing/mocks"
 	"github.com/OffchainLabs/bold/testing/setup"
@@ -278,8 +279,9 @@ func setupPoster(t *testing.T) (*Manager, *mocks.MockProtocol, *mocks.MockStateM
 	_, err := setup.ChainsWithEdgeChallengeManager()
 	require.NoError(t, err)
 	p := &Manager{
-		chain:        chain,
-		stateManager: stateProvider,
+		chain:               chain,
+		stateManager:        stateProvider,
+		submittedAssertions: threadsafe.NewSet[common.Hash](),
 	}
 	return p, chain, stateProvider
 }

--- a/assertions/scanner.go
+++ b/assertions/scanner.go
@@ -16,6 +16,7 @@ import (
 
 	protocol "github.com/OffchainLabs/bold/chain-abstraction"
 	"github.com/OffchainLabs/bold/challenge-manager/types"
+	"github.com/OffchainLabs/bold/containers/threadsafe"
 	l2stateprovider "github.com/OffchainLabs/bold/layer2-state-provider"
 	retry "github.com/OffchainLabs/bold/runtime"
 	"github.com/OffchainLabs/bold/solgen/go/rollupgen"
@@ -45,7 +46,7 @@ type Manager struct {
 	backend                     bind.ContractBackend
 	challengeCreator            types.ChallengeCreator
 	challengeReader             types.ChallengeReader
-	stateProvider               l2stateprovider.Provider
+	stateProvider               l2stateprovider.ExecutionStateAgreementChecker
 	pollInterval                time.Duration
 	confirmationAttemptInterval time.Duration
 	rollupAddr                  common.Address
@@ -55,6 +56,7 @@ type Manager struct {
 	assertionsProcessedCount    uint64
 	stateManager                l2stateprovider.ExecutionProvider
 	postInterval                time.Duration
+	submittedAssertions         *threadsafe.Set[common.Hash]
 }
 
 // NewManager creates a manager from the required dependencies.
@@ -91,6 +93,7 @@ func NewManager(
 		assertionsProcessedCount:    0,
 		stateManager:                stateManager,
 		postInterval:                postInterval,
+		submittedAssertions:         threadsafe.NewSet[common.Hash](),
 	}, nil
 }
 
@@ -168,6 +171,18 @@ func (s *Manager) Start(ctx context.Context) {
 	}
 }
 
+func (s *Manager) ForksDetected() uint64 {
+	return s.forksDetectedCount
+}
+
+func (s *Manager) ChallengesSubmitted() uint64 {
+	return s.challengesSubmittedCount
+}
+
+func (s *Manager) AssertionsProcessed() uint64 {
+	return s.assertionsProcessedCount
+}
+
 func (s *Manager) checkForAssertionAdded(
 	ctx context.Context,
 	filterer *rollupgen.RollupUserLogicFilterer,
@@ -192,111 +207,211 @@ func (s *Manager) checkForAssertionAdded(
 			)
 		}
 		assertionHash := protocol.AssertionHash{Hash: it.Event.AssertionHash}
+
+		// Try to confirm the assertion in the background.
 		go s.keepTryingAssertionConfirmation(ctx, assertionHash)
-		_, processErr := retry.UntilSucceeds(ctx, func() (bool, error) {
-			return true, s.ProcessAssertionCreation(ctx, assertionHash)
-		})
-		if processErr != nil {
-			return processErr
-		}
+
+		// Try to process the assertion creation event in the background
+		// to not block the processing of other incoming events.
+		go func() {
+			_, processErr := retry.UntilSucceeds(ctx, func() (bool, error) {
+				return true, s.ProcessAssertionCreationEvent(ctx, assertionHash)
+			}, retry.WithInterval(time.Minute))
+			if processErr != nil {
+				srvlog.Error(
+					"Could not process assertion creation after retries",
+					log.Ctx{"err": processErr},
+				)
+			}
+		}()
 	}
 	return nil
 }
 
-func (s *Manager) ProcessAssertionCreation(
+// ProcessAssertionCreationEvent by checking if we agree with its claimed state.
+// If we do not, we attempt to post a rival assertion along the fork and initiate a challenge
+// if we are configured to do so. If we have not yet caught up to the claimed state,
+// this function will then return an error.
+func (m *Manager) ProcessAssertionCreationEvent(
 	ctx context.Context,
 	assertionHash protocol.AssertionHash,
 ) error {
+	// Ignore assertions we have submitted ourselves.
+	if m.submittedAssertions.Has(assertionHash.Hash) {
+		return nil
+	}
 	if assertionHash.Hash == (common.Hash{}) {
 		return nil // Assertions cannot have a zero hash, not even genesis.
 	}
-	creationInfo, err := s.chain.ReadAssertionCreationInfo(ctx, assertionHash)
+	creationInfo, err := m.chain.ReadAssertionCreationInfo(ctx, assertionHash)
 	if err != nil {
 		return errors.Wrapf(err, "could not read assertion creation info for %#x", assertionHash.Hash)
 	}
 	if creationInfo.ParentAssertionHash == (common.Hash{}) {
 		return nil // Skip processing genesis, as it has a parent assertion hash of 0x0.
 	}
-	goGs := protocol.GoGlobalStateFromSolidity(creationInfo.AfterState.GlobalState)
-	srvlog.Info("Processed assertion creation event", log.Ctx{
-		"validatorName":       s.validatorName,
-		"globalState":         goGs,
-		"machineFinishedHash": crypto.Keccak256Hash([]byte("Machine finished:"), goGs.Hash().Bytes()),
-		"assertionHash":       assertionHash,
-	})
-	s.assertionsProcessedCount++
-	prevAssertion, err := s.chain.GetAssertion(ctx, protocol.AssertionHash{Hash: creationInfo.ParentAssertionHash})
-	if err != nil {
-		return err
-	}
-	hasSecondChild, err := prevAssertion.HasSecondChild()
-	if err != nil {
-		return err
-	}
-	if !hasSecondChild {
-		srvlog.Info("No fork detected in assertion chain", log.Ctx{"validatorName": s.validatorName})
-		return nil
-	}
-	s.forksDetectedCount++
-	execState := protocol.GoExecutionStateFromSolidity(creationInfo.AfterState)
-	if !creationInfo.InboxMaxCount.IsUint64() {
-		return errors.New("inbox max count was not a uint64")
-	}
-	batchIndex := creationInfo.InboxMaxCount.Uint64() - 1
-	srvlog.Info("Checking if agrees with execution state", log.Ctx{
-		"validatorName": s.validatorName,
-		"batchIndex":    batchIndex,
-		"execState":     fmt.Sprintf("%+v", execState),
-	})
-	err = s.stateProvider.AgreesWithExecutionState(ctx, execState)
+
+	// Check if we agree with the assertion's claimed state.
+	claimedState := protocol.GoExecutionStateFromSolidity(creationInfo.AfterState)
+	err = m.stateProvider.AgreesWithExecutionState(ctx, claimedState)
 	switch {
 	case errors.Is(err, l2stateprovider.ErrNoExecutionState):
-		return nil
+		// If we disagree with the execution state, we should try to post the rival
+		// assertion that we believe is correct and initiate a challenge if possible.
+		return m.postRivalAssertionAndChallenge(ctx, creationInfo)
+	case errors.Is(err, l2stateprovider.ErrChainCatchingUp):
+		// Otherwise, we return the error that we are still catching up to the
+		// execution state claimed by the assertion, and this function will be retried
+		// by the caller if wrapped in a retryable call.
+		return fmt.Errorf(
+			"chain still catching up to processed execution state - "+
+				"will reattempt assertion processing when caught up: %w",
+			l2stateprovider.ErrChainCatchingUp,
+		)
 	case err != nil:
 		return err
-	default:
 	}
-
-	if s.challengeReader.Mode() == types.DefensiveMode || s.challengeReader.Mode() == types.MakeMode {
-
-		// Generating a random integer between 0 and max delay second to wait before challenging.
-		// This is to avoid all validators challenging at the same time.
-		mds := 1 // default max delay seconds to 1 to avoid panic
-		if s.challengeReader.MaxDelaySeconds() > 1 {
-			mds = s.challengeReader.MaxDelaySeconds()
-		}
-		randSecs, err := randUint64(uint64(mds))
-		if err != nil {
-			return err
-		}
-		srvlog.Info("Waiting before challenging", log.Ctx{"delay": randSecs})
-		time.Sleep(time.Duration(randSecs) * time.Second)
-
-		if err := s.challengeCreator.ChallengeAssertion(ctx, assertionHash); err != nil {
-			return err
-		}
-		s.challengesSubmittedCount++
-		return nil
-	}
-
-	srvlog.Error("Detected invalid assertion, but not configured to challenge", log.Ctx{
-		"parentAssertionHash":   creationInfo.ParentAssertionHash,
-		"detectedAssertionHash": assertionHash,
-		"batchIndex":            batchIndex,
+	// If no error, this means we agree with the claimed assertion state
+	// so there is no action to take.
+	machineFinishedHash := crypto.Keccak256Hash([]byte("Machine finished:"), claimedState.GlobalState.Hash().Bytes())
+	srvlog.Info("Agreed with incoming assertion", log.Ctx{
+		"validatorName":       m.validatorName,
+		"claimedState":        fmt.Sprintf("%+v", claimedState),
+		"machineFinishedHash": machineFinishedHash,
+		"assertionHash":       assertionHash,
 	})
 	return nil
 }
 
-func (s *Manager) ForksDetected() uint64 {
-	return s.forksDetectedCount
+// Attempts to post a rival assertion to a given assertion and then attempts to
+// open a challenge on that fork in the chain if configured to do so.
+func (m *Manager) postRivalAssertionAndChallenge(
+	ctx context.Context,
+	creationInfo *protocol.AssertionCreatedInfo,
+) error {
+	if !creationInfo.InboxMaxCount.IsUint64() {
+		return errors.New("inbox max count not a uint64")
+	}
+	batchCount := creationInfo.InboxMaxCount.Uint64()
+	claimedState := protocol.GoExecutionStateFromSolidity(creationInfo.AfterState)
+	logFields := log.Ctx{
+		"validatorName":         m.validatorName,
+		"parentAssertionHash":   creationInfo.ParentAssertionHash,
+		"detectedAssertionHash": creationInfo.AssertionHash,
+		"batchCount":            batchCount,
+		"claimedExecutionState": fmt.Sprintf("%+v", claimedState),
+	}
+	if !m.canRespondToAssertion() {
+		srvlog.Warn("Detected invalid assertion, but not configured to challenge", logFields)
+		return nil
+	}
+
+	srvlog.Info("Disagreed with execution state from observed assertion", logFields)
+
+	// Post what we believe is the correct rival assertion that follows the ancestor we agree with.
+	correctRivalAssertion, err := m.maybePostRivalAssertion(ctx, creationInfo)
+	if err != nil {
+		return err
+	}
+	correctClaimedAssertionHash := correctRivalAssertion.Id()
+
+	// Generating a random integer between 0 and max delay second to wait before challenging.
+	// This is to avoid all validators challenging at the same time.
+	// TODO: Abstract into a smaller function.
+	mds := 1 // default max delay seconds to 1 to avoid panic
+	if m.challengeReader.MaxDelaySeconds() > 1 {
+		mds = m.challengeReader.MaxDelaySeconds()
+	}
+	randSecs, err := randUint64(uint64(mds))
+	if err != nil {
+		return err
+	}
+	srvlog.Info("Waiting before submitting challenge on assertion", log.Ctx{"delay": randSecs})
+	time.Sleep(time.Duration(randSecs) * time.Second)
+
+	if err := m.challengeCreator.ChallengeAssertion(ctx, correctClaimedAssertionHash); err != nil {
+		return err
+	}
+	m.challengesSubmittedCount++
+	return nil
+
 }
 
-func (s *Manager) ChallengesSubmitted() uint64 {
-	return s.challengesSubmittedCount
+// Attempt to post a rival assertion based on the last agreed with ancestor
+// of a given assertion.
+//
+// If this parent assertion already has a rival we agree with that arleady exists
+// then this function will return that assertion.
+func (m *Manager) maybePostRivalAssertion(
+	ctx context.Context, creationInfo *protocol.AssertionCreatedInfo,
+) (protocol.Assertion, error) {
+	latestAgreedWithAncestor, err := m.findLastAgreedWithAncestor(ctx, creationInfo)
+	if err != nil {
+		return nil, err
+	}
+	// Post what we believe is the correct assertion that follows the ancestor we agree with.
+	staked, err := m.chain.IsStaked(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// If the validator is already staked, we post an assertion and move existing stake to it.
+	if staked {
+		assertion, err := m.postAssertionBasedOnParent(
+			ctx, latestAgreedWithAncestor, m.chain.StakeOnNewAssertion,
+		)
+		if err != nil {
+			return nil, err
+		}
+		m.submittedAssertions.Insert(assertion.Id().Hash)
+		return assertion, nil
+	}
+	// Otherwise, we post a new assertion and place a new stake on it.
+	assertion, err := m.postAssertionBasedOnParent(
+		ctx, latestAgreedWithAncestor, m.chain.NewStakeOnNewAssertion,
+	)
+	if err != nil {
+		return nil, err
+	}
+	m.submittedAssertions.Insert(assertion.Id().Hash)
+	return assertion, nil
 }
 
-func (s *Manager) AssertionsProcessed() uint64 {
-	return s.assertionsProcessedCount
+// Look back until we find the ancestor we agree with for the given assertion.
+func (m *Manager) findLastAgreedWithAncestor(
+	ctx context.Context, assertionCreationInfo *protocol.AssertionCreatedInfo,
+) (*protocol.AssertionCreatedInfo, error) {
+	latestConfirmed, err := m.chain.LatestConfirmed(ctx)
+	if err != nil {
+		return nil, err
+	}
+	latestConfirmedInfo, err := m.chain.ReadAssertionCreationInfo(ctx, latestConfirmed.Id())
+	if err != nil {
+		return nil, err
+	}
+	agreedWithAncestor := latestConfirmed.Id().Hash
+	cursor := assertionCreationInfo.ParentAssertionHash
+	for cursor != agreedWithAncestor {
+		// Get the cursor's creation info.
+		parentCreationInfo, err := m.chain.ReadAssertionCreationInfo(
+			ctx, protocol.AssertionHash{Hash: cursor},
+		)
+		if err != nil {
+			return nil, err
+		}
+		parentExecState := protocol.GoExecutionStateFromSolidity(parentCreationInfo.AfterState)
+		if err = m.stateProvider.AgreesWithExecutionState(ctx, parentExecState); err != nil {
+			if errors.Is(err, l2stateprovider.ErrNoExecutionState) {
+				// Disagreed with parent. This means we should look at the
+				// grandparent and continue our loop.
+				cursor = parentCreationInfo.ParentAssertionHash
+				continue
+			}
+			return nil, err
+		}
+		// No error means we agree with this parent. We can break the loop.
+		return parentCreationInfo, nil
+	}
+	return latestConfirmedInfo, nil
 }
 
 func (s *Manager) keepTryingAssertionConfirmation(ctx context.Context, assertionHash protocol.AssertionHash) {
@@ -328,6 +443,11 @@ func (s *Manager) keepTryingAssertionConfirmation(ctx context.Context, assertion
 			return
 		}
 	}
+}
+
+// Returns true if the manager can respond to an assertion with a challenge.
+func (m *Manager) canRespondToAssertion() bool {
+	return m.challengeReader.Mode() == types.DefensiveMode || m.challengeReader.Mode() == types.MakeMode
 }
 
 func randUint64(max uint64) (uint64, error) {

--- a/assertions/scanner.go
+++ b/assertions/scanner.go
@@ -356,7 +356,7 @@ func (m *Manager) maybePostRivalAssertion(
 	}
 	// If the validator is already staked, we post an assertion and move existing stake to it.
 	if staked {
-		assertion, err := m.postAssertionBasedOnParent(
+		assertion, err := m.PostAssertionBasedOnParent(
 			ctx, latestAgreedWithAncestor, m.chain.StakeOnNewAssertion,
 		)
 		if err != nil {
@@ -366,7 +366,7 @@ func (m *Manager) maybePostRivalAssertion(
 		return assertion, nil
 	}
 	// Otherwise, we post a new assertion and place a new stake on it.
-	assertion, err := m.postAssertionBasedOnParent(
+	assertion, err := m.PostAssertionBasedOnParent(
 		ctx, latestAgreedWithAncestor, m.chain.NewStakeOnNewAssertion,
 	)
 	if err != nil {

--- a/assertions/scanner_internals_test.go
+++ b/assertions/scanner_internals_test.go
@@ -1,0 +1,122 @@
+package assertions
+
+import (
+	"context"
+	"testing"
+
+	protocol "github.com/OffchainLabs/bold/chain-abstraction"
+	l2stateprovider "github.com/OffchainLabs/bold/layer2-state-provider"
+	"github.com/OffchainLabs/bold/solgen/go/rollupgen"
+	"github.com/OffchainLabs/bold/testing/mocks"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestFindLastAgreedWithAncestor(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("Error reading assertion creation info", func(t *testing.T) {
+		chain := &mocks.MockProtocol{}
+		genesis := common.BytesToHash([]byte("genesis"))
+		assertion := &mocks.MockAssertion{MockId: protocol.AssertionHash{Hash: genesis}}
+		chain.On("LatestConfirmed", ctx).Return(assertion, nil)
+		chain.On("ReadAssertionCreationInfo", ctx, protocol.AssertionHash{Hash: genesis}).Return(&protocol.AssertionCreatedInfo{}, errors.New("error"))
+		manager := &Manager{chain: chain}
+
+		_, err := manager.findLastAgreedWithAncestor(ctx, &protocol.AssertionCreatedInfo{})
+		assert.Error(t, err)
+	})
+
+	t.Run("Reaches latest confirmed without finding agreed upon ancestor", func(t *testing.T) {
+		chain := &mocks.MockProtocol{}
+		stateProvider := &mocks.MockStateManager{}
+		genesis := common.BytesToHash([]byte("genesis"))
+		parent := common.BytesToHash([]byte("parent-of-latest"))
+		latest := common.BytesToHash([]byte("latest"))
+		genesisAssertion := &mocks.MockAssertion{MockId: protocol.AssertionHash{Hash: genesis}}
+		chain.On("LatestConfirmed", ctx).Return(genesisAssertion, nil)
+
+		chain.On("ReadAssertionCreationInfo", ctx, protocol.AssertionHash{Hash: genesis}).Return(
+			&protocol.AssertionCreatedInfo{AssertionHash: genesis}, nil,
+		)
+		chain.On("ReadAssertionCreationInfo", ctx, protocol.AssertionHash{Hash: parent}).Return(
+			&protocol.AssertionCreatedInfo{AssertionHash: parent, ParentAssertionHash: genesis}, nil,
+		)
+
+		stateProvider.On("AgreesWithExecutionState", ctx, mock.Anything).Return(l2stateprovider.ErrNoExecutionState)
+		manager := &Manager{chain: chain, stateProvider: stateProvider}
+
+		ancestor, err := manager.findLastAgreedWithAncestor(ctx, &protocol.AssertionCreatedInfo{
+			AssertionHash:       latest,
+			ParentAssertionHash: parent,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, genesis, ancestor.AssertionHash)
+	})
+
+	t.Run("Finds agreed upon ancestor before latest confirmed", func(t *testing.T) {
+		chain := &mocks.MockProtocol{}
+		stateProvider := &mocks.MockStateManager{}
+		genesis := common.BytesToHash([]byte("genesis"))
+		parent := common.BytesToHash([]byte("parent-of-latest"))
+		latest := common.BytesToHash([]byte("latest"))
+		genesisAssertion := &mocks.MockAssertion{MockId: protocol.AssertionHash{Hash: genesis}}
+		chain.On("LatestConfirmed", ctx).Return(genesisAssertion, nil)
+
+		chain.On("ReadAssertionCreationInfo", ctx, protocol.AssertionHash{Hash: genesis}).Return(
+			&protocol.AssertionCreatedInfo{AssertionHash: genesis}, nil,
+		)
+		execState := rollupgen.ExecutionState{
+			GlobalState: rollupgen.GlobalState{
+				U64Vals: [2]uint64{1, 0},
+			},
+			MachineStatus: uint8(protocol.MachineStatusFinished),
+		}
+		chain.On("ReadAssertionCreationInfo", ctx, protocol.AssertionHash{Hash: parent}).Return(
+			&protocol.AssertionCreatedInfo{
+				AssertionHash:       parent,
+				ParentAssertionHash: genesis,
+				AfterState:          execState,
+			}, nil,
+		)
+
+		goExec := protocol.GoExecutionStateFromSolidity(execState)
+		stateProvider.On("AgreesWithExecutionState", ctx, goExec).Return(nil)
+		manager := &Manager{chain: chain, stateProvider: stateProvider}
+
+		ancestor, err := manager.findLastAgreedWithAncestor(ctx, &protocol.AssertionCreatedInfo{
+			AssertionHash:       latest,
+			ParentAssertionHash: parent,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, parent, ancestor.AssertionHash)
+	})
+
+	t.Run("State provider returns any other error", func(t *testing.T) {
+		chain := &mocks.MockProtocol{}
+		stateProvider := &mocks.MockStateManager{}
+		genesis := common.BytesToHash([]byte("genesis"))
+		parent := common.BytesToHash([]byte("parent-of-latest"))
+		latest := common.BytesToHash([]byte("latest"))
+		genesisAssertion := &mocks.MockAssertion{MockId: protocol.AssertionHash{Hash: genesis}}
+		chain.On("LatestConfirmed", ctx).Return(genesisAssertion, nil)
+
+		chain.On("ReadAssertionCreationInfo", ctx, protocol.AssertionHash{Hash: genesis}).Return(
+			&protocol.AssertionCreatedInfo{AssertionHash: genesis}, nil,
+		)
+		chain.On("ReadAssertionCreationInfo", ctx, protocol.AssertionHash{Hash: parent}).Return(
+			&protocol.AssertionCreatedInfo{AssertionHash: parent, ParentAssertionHash: genesis}, nil,
+		)
+
+		stateProvider.On("AgreesWithExecutionState", ctx, mock.Anything).Return(errors.New("failed"))
+		manager := &Manager{chain: chain, stateProvider: stateProvider}
+
+		_, err := manager.findLastAgreedWithAncestor(ctx, &protocol.AssertionCreatedInfo{
+			AssertionHash:       latest,
+			ParentAssertionHash: parent,
+		})
+		assert.ErrorContains(t, err, "failed")
+	})
+}

--- a/assertions/scanner_test.go
+++ b/assertions/scanner_test.go
@@ -50,7 +50,7 @@ func TestScanner_ProcessAssertionCreation(t *testing.T) {
 		scanner, err := assertions.NewManager(p, mockStateProvider, cfg.Backend, manager, cfg.Addrs.Rollup, "", time.Second, time.Second, &mocks.MockStateManager{}, time.Second)
 		require.NoError(t, err)
 
-		err = scanner.ProcessAssertionCreation(ctx, ev.Id())
+		err = scanner.ProcessAssertionCreationEvent(ctx, ev.Id())
 		require.NoError(t, err)
 		require.Equal(t, uint64(1), scanner.AssertionsProcessed())
 		require.Equal(t, uint64(0), scanner.ForksDetected())
@@ -76,7 +76,7 @@ func TestScanner_ProcessAssertionCreation(t *testing.T) {
 		scanner, err := assertions.NewManager(createdData.Chains[1], createdData.HonestStateManager, createdData.Backend, manager, createdData.Addrs.Rollup, "", time.Second, time.Second, &mocks.MockStateManager{}, time.Second)
 		require.NoError(t, err)
 
-		err = scanner.ProcessAssertionCreation(ctx, createdData.Leaf1.Id())
+		err = scanner.ProcessAssertionCreationEvent(ctx, createdData.Leaf1.Id())
 		require.NoError(t, err)
 
 		otherManager, err := challengemanager.New(
@@ -93,10 +93,10 @@ func TestScanner_ProcessAssertionCreation(t *testing.T) {
 		otherScanner, err := assertions.NewManager(createdData.Chains[0], createdData.EvilStateManager, createdData.Backend, otherManager, createdData.Addrs.Rollup, "", time.Second, time.Second, &mocks.MockStateManager{}, time.Second)
 		require.NoError(t, err)
 
-		err = otherScanner.ProcessAssertionCreation(ctx, createdData.Leaf2.Id())
+		err = otherScanner.ProcessAssertionCreationEvent(ctx, createdData.Leaf2.Id())
 		require.NoError(t, err)
 
-		err = otherScanner.ProcessAssertionCreation(ctx, createdData.Leaf2.Id())
+		err = otherScanner.ProcessAssertionCreationEvent(ctx, createdData.Leaf2.Id())
 		require.NoError(t, err)
 
 		require.Equal(t, uint64(2), otherScanner.AssertionsProcessed())
@@ -123,7 +123,7 @@ func TestScanner_ProcessAssertionCreation(t *testing.T) {
 		scanner, err := assertions.NewManager(createdData.Chains[1], createdData.HonestStateManager, createdData.Backend, manager, createdData.Addrs.Rollup, "", time.Second, time.Second, &mocks.MockStateManager{}, time.Second)
 		require.NoError(t, err)
 
-		err = scanner.ProcessAssertionCreation(ctx, createdData.Leaf1.Id())
+		err = scanner.ProcessAssertionCreationEvent(ctx, createdData.Leaf1.Id())
 		require.NoError(t, err)
 
 		otherManager, err := challengemanager.New(
@@ -140,10 +140,10 @@ func TestScanner_ProcessAssertionCreation(t *testing.T) {
 		otherScanner, err := assertions.NewManager(createdData.Chains[0], createdData.EvilStateManager, createdData.Backend, otherManager, createdData.Addrs.Rollup, "", time.Second, time.Second, &mocks.MockStateManager{}, time.Second)
 		require.NoError(t, err)
 
-		err = otherScanner.ProcessAssertionCreation(ctx, createdData.Leaf2.Id())
+		err = otherScanner.ProcessAssertionCreationEvent(ctx, createdData.Leaf2.Id())
 		require.NoError(t, err)
 
-		err = otherScanner.ProcessAssertionCreation(ctx, createdData.Leaf2.Id())
+		err = otherScanner.ProcessAssertionCreationEvent(ctx, createdData.Leaf2.Id())
 		require.NoError(t, err)
 
 		require.Equal(t, uint64(2), otherScanner.AssertionsProcessed())

--- a/assertions/scanner_test.go
+++ b/assertions/scanner_test.go
@@ -47,6 +47,7 @@ func TestScanner_ProcessAssertionCreation(t *testing.T) {
 		}, nil)
 		p.On("GetAssertion", ctx, mockId(2)).Return(ev, nil)
 		p.On("GetAssertion", ctx, mockId(1)).Return(prev, nil)
+		mockStateProvider.On("AgreesWithExecutionState", ctx, &protocol.ExecutionState{}).Return(nil)
 		scanner, err := assertions.NewManager(p, mockStateProvider, cfg.Backend, manager, cfg.Addrs.Rollup, "", time.Second, time.Second, &mocks.MockStateManager{}, time.Second)
 		require.NoError(t, err)
 
@@ -73,10 +74,11 @@ func TestScanner_ProcessAssertionCreation(t *testing.T) {
 			challengemanager.WithEdgeTrackerWakeInterval(100*time.Millisecond),
 		)
 		require.NoError(t, err)
-		scanner, err := assertions.NewManager(createdData.Chains[1], createdData.HonestStateManager, createdData.Backend, manager, createdData.Addrs.Rollup, "", time.Second, time.Second, &mocks.MockStateManager{}, time.Second)
+
+		scanner, err := assertions.NewManager(createdData.Chains[1], createdData.HonestStateManager, createdData.Backend, manager, createdData.Addrs.Rollup, "", time.Second, time.Second, createdData.HonestStateManager, time.Second)
 		require.NoError(t, err)
 
-		err = scanner.ProcessAssertionCreationEvent(ctx, createdData.Leaf1.Id())
+		err = scanner.ProcessAssertionCreationEvent(ctx, createdData.Leaf2.Id())
 		require.NoError(t, err)
 
 		otherManager, err := challengemanager.New(
@@ -90,18 +92,16 @@ func TestScanner_ProcessAssertionCreation(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		otherScanner, err := assertions.NewManager(createdData.Chains[0], createdData.EvilStateManager, createdData.Backend, otherManager, createdData.Addrs.Rollup, "", time.Second, time.Second, &mocks.MockStateManager{}, time.Second)
+		otherScanner, err := assertions.NewManager(createdData.Chains[0], createdData.EvilStateManager, createdData.Backend, otherManager, createdData.Addrs.Rollup, "", time.Second, time.Second, createdData.EvilStateManager, time.Second)
 		require.NoError(t, err)
 
-		err = otherScanner.ProcessAssertionCreationEvent(ctx, createdData.Leaf2.Id())
+		err = otherScanner.ProcessAssertionCreationEvent(ctx, createdData.Leaf1.Id())
 		require.NoError(t, err)
 
-		err = otherScanner.ProcessAssertionCreationEvent(ctx, createdData.Leaf2.Id())
-		require.NoError(t, err)
-
-		require.Equal(t, uint64(2), otherScanner.AssertionsProcessed())
-		require.Equal(t, uint64(2), otherScanner.ForksDetected())
-		require.Equal(t, uint64(2), otherScanner.ChallengesSubmitted())
+		require.Equal(t, uint64(1), otherScanner.AssertionsProcessed())
+		require.Equal(t, uint64(1), otherScanner.ChallengesSubmitted())
+		require.Equal(t, uint64(1), scanner.AssertionsProcessed())
+		require.Equal(t, uint64(1), scanner.ChallengesSubmitted())
 	})
 	t.Run("defensive validator can still challenge leaf", func(t *testing.T) {
 		ctx := context.Background()
@@ -120,10 +120,10 @@ func TestScanner_ProcessAssertionCreation(t *testing.T) {
 			challengemanager.WithEdgeTrackerWakeInterval(100*time.Millisecond),
 		)
 		require.NoError(t, err)
-		scanner, err := assertions.NewManager(createdData.Chains[1], createdData.HonestStateManager, createdData.Backend, manager, createdData.Addrs.Rollup, "", time.Second, time.Second, &mocks.MockStateManager{}, time.Second)
+		scanner, err := assertions.NewManager(createdData.Chains[1], createdData.HonestStateManager, createdData.Backend, manager, createdData.Addrs.Rollup, "", time.Second, time.Second, createdData.HonestStateManager, time.Second)
 		require.NoError(t, err)
 
-		err = scanner.ProcessAssertionCreationEvent(ctx, createdData.Leaf1.Id())
+		err = scanner.ProcessAssertionCreationEvent(ctx, createdData.Leaf2.Id())
 		require.NoError(t, err)
 
 		otherManager, err := challengemanager.New(
@@ -137,18 +137,16 @@ func TestScanner_ProcessAssertionCreation(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		otherScanner, err := assertions.NewManager(createdData.Chains[0], createdData.EvilStateManager, createdData.Backend, otherManager, createdData.Addrs.Rollup, "", time.Second, time.Second, &mocks.MockStateManager{}, time.Second)
+		otherScanner, err := assertions.NewManager(createdData.Chains[0], createdData.EvilStateManager, createdData.Backend, otherManager, createdData.Addrs.Rollup, "", time.Second, time.Second, createdData.EvilStateManager, time.Second)
 		require.NoError(t, err)
 
-		err = otherScanner.ProcessAssertionCreationEvent(ctx, createdData.Leaf2.Id())
+		err = otherScanner.ProcessAssertionCreationEvent(ctx, createdData.Leaf1.Id())
 		require.NoError(t, err)
 
-		err = otherScanner.ProcessAssertionCreationEvent(ctx, createdData.Leaf2.Id())
-		require.NoError(t, err)
-
-		require.Equal(t, uint64(2), otherScanner.AssertionsProcessed())
-		require.Equal(t, uint64(2), otherScanner.ForksDetected())
-		require.Equal(t, uint64(2), otherScanner.ChallengesSubmitted())
+		require.Equal(t, uint64(1), otherScanner.AssertionsProcessed())
+		require.Equal(t, uint64(1), otherScanner.ChallengesSubmitted())
+		require.Equal(t, uint64(1), scanner.AssertionsProcessed())
+		require.Equal(t, uint64(1), scanner.ChallengesSubmitted())
 	})
 }
 

--- a/chain-abstraction/sol-implementation/assertion_chain.go
+++ b/chain-abstraction/sol-implementation/assertion_chain.go
@@ -655,6 +655,18 @@ func handleCreateAssertionError(err error, blockHash common.Hash) error {
 	}
 	errS := err.Error()
 	switch {
+	case strings.Contains(errS, "EXPECTED_ASSERTION_SEEN"):
+		return errors.Wrapf(
+			ErrAlreadyExists,
+			"commit block hash %#x",
+			blockHash,
+		)
+	case strings.Contains(errS, "already known"):
+		return errors.Wrapf(
+			ErrAlreadyExists,
+			"commit block hash %#x",
+			blockHash,
+		)
 	case strings.Contains(errS, "Assertion already exists"):
 		return errors.Wrapf(
 			ErrAlreadyExists,

--- a/layer2-state-provider/provider.go
+++ b/layer2-state-provider/provider.go
@@ -19,6 +19,7 @@ import (
 
 var (
 	ErrNoExecutionState = errors.New("chain does not have execution state")
+	ErrChainCatchingUp  = errors.New("chain is catching up to the execution state")
 )
 
 // Batch index for an Arbitrum L2 state.
@@ -56,6 +57,10 @@ type Provider interface {
 type ExecutionProvider interface {
 	// Produces the L2 execution state to assert to after the processing the given batch count.
 	ExecutionStateAfterBatchCount(ctx context.Context, batchCount uint64) (*protocol.ExecutionState, error)
+	ExecutionStateAgreementChecker
+}
+
+type ExecutionStateAgreementChecker interface {
 	// If the state manager locally has this execution state, returns its message count and no error.
 	// Returns ErrChainCatchingUp if catching up to chain.
 	// Returns ErrNoExecutionState if the state manager does not have this execution state.

--- a/testing/endtoend/basic_local_test.go
+++ b/testing/endtoend/basic_local_test.go
@@ -274,20 +274,20 @@ func testChallengeProtocol_AliceAndBob(t *testing.T, be backend.Backend, scenari
 			t.Fatal(err)
 		}
 
-		aliceLeaf, err := alicePoster.PostAssertionAndNewStake(ctx)
+		aliceLeaf, err := alicePoster.PostAssertion(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
-		bobLeaf, err := bobPoster.PostAssertionAndNewStake(ctx)
+		bobLeaf, err := bobPoster.PostAssertion(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		// Scan for created assertions.
-		if err := alicePoster.ProcessAssertionCreation(ctx, aliceLeaf.Id()); err != nil {
+		if err := alicePoster.ProcessAssertionCreationEvent(ctx, aliceLeaf.Id()); err != nil {
 			t.Fatal(err)
 		}
-		if err := bobPoster.ProcessAssertionCreation(ctx, bobLeaf.Id()); err != nil {
+		if err := bobPoster.ProcessAssertionCreationEvent(ctx, bobLeaf.Id()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -341,12 +341,12 @@ func testSyncBobStopsCharlieJoins(t *testing.T, be backend.Backend, s *Challenge
 		require.NoError(t, err)
 		bobPoster, err := assertions.NewManager(bChain, s.BobStateManager, be.Client(), bob, rollup, "bob", time.Hour, time.Second*10, s.BobStateManager, time.Hour)
 		require.NoError(t, err)
-		aliceLeaf, err := alicePoster.PostAssertionAndNewStake(ctx)
+		aliceLeaf, err := alicePoster.PostAssertion(ctx)
 		require.NoError(t, err)
-		bobLeaf, err := bobPoster.PostAssertionAndNewStake(bobCtx)
+		bobLeaf, err := bobPoster.PostAssertion(bobCtx)
 		require.NoError(t, err)
-		require.NoError(t, alicePoster.ProcessAssertionCreation(ctx, aliceLeaf.Id()))
-		require.NoError(t, bobPoster.ProcessAssertionCreation(bobCtx, bobLeaf.Id()))
+		require.NoError(t, alicePoster.ProcessAssertionCreationEvent(ctx, aliceLeaf.Id()))
+		require.NoError(t, bobPoster.ProcessAssertionCreationEvent(bobCtx, bobLeaf.Id()))
 
 		// Alice and bob starts to challenge each other.
 		alice.Start(ctx)

--- a/testing/setup/rollup_stack.go
+++ b/testing/setup/rollup_stack.go
@@ -7,6 +7,7 @@ package setup
 import (
 	"context"
 	"crypto/ecdsa"
+	"fmt"
 	"math/big"
 
 	protocol "github.com/OffchainLabs/bold/chain-abstraction"
@@ -124,6 +125,7 @@ func CreateTwoValidatorFork(
 	if err != nil {
 		return nil, err
 	}
+	fmt.Printf("Honest post %+v and evil post %+v\n", honestPostState, evilPostState)
 
 	return &CreatedValidatorFork{
 		Leaf1:              assertion,


### PR DESCRIPTION
This PR fixes several flaws and bad assumptions we make in how we deal with posting and scanning for assertions posted to the rollup contracts.

## Minor Fixes

- [x] If an assertion already exists, when posting, do not log an error
- [x] Keep track of assertions we submitted ourselves to avoid unnecessarily processing their creation events
- [x] When processing an assertion creation event, we do so in a dedicated goroutine that retries processing until success. This process can be error prone as it depends on an L1 client and L2 validation node connection, so we want to make sure it eventually succeeds. We also want to avoid blocking the processing of other assertion creation events if received by moving this to a goroutine
- [x] We were initializing and starting the assertions service twice. This reduces it to only once

## Major Fixes

When we see an assertion creation event, we now do the following:
- We fetch its claimed execution state. If we are still catching up to the chain, we return an error ErrCatchingUp
- If we agree with it, we log that we agree and do nothing else
- If we disagree, we try to post a rival assertion to it and initiate a challenge if we are configured to do so

It's important to note the last point isn't as simple as it seems. Consider the following scenario where the latest assertion creation event we receive is `D`.

```mermaid
  graph LR;
      A-->B;
      B-->C;
      C-->D;
```

However, we _also_ disagree with `C`! Instead, we need to look back until we find the latest ancestor we agree with. Then, we must open a rival assertion to that ancestor and initiate a challenge. In this case, we must open a rival assertion to `B`

```mermaid
  graph LR;
      A-->B;
      B-->C;
      C-->D;
      A-->Bcorrect
```

