### PR TITLE
Improve BOLD Log and Assertion Confirmation UX

### DIFF
--- a/assertions/scanner.go
+++ b/assertions/scanner.go
@@ -476,15 +476,15 @@ func (m *Manager) keepTryingAssertionConfirmation(ctx context.Context, assertion
 		return
 	}
 	for {
-		if m.assertionConfirmed(ctx, assertionHash) {
-			return
-		}
 		ticker := time.NewTicker(m.confirmationAttemptInterval)
+		defer ticker.Stop()
 		select {
 		case <-ctx.Done():
-			ticker.Stop()
 			return
 		case <-ticker.C:
+			if m.assertionConfirmed(ctx, assertionHash) {
+				return
+			}
 		}
 	}
 }
@@ -503,38 +503,46 @@ func (m *Manager) assertionConfirmed(ctx context.Context, assertionHash protocol
 		srvlog.Info("Assertion confirmed", log.Ctx{"assertionHash": assertionHash.Hash})
 		return true
 	}
+	creationInfo, err := m.chain.ReadAssertionCreationInfo(ctx, assertionHash)
+	if err != nil {
+		srvlog.Error("Could not get assertion creation info by hash", log.Ctx{"err": err, "assertionHash": assertionHash.Hash})
+		return false
+	}
+	prevCreationInfo, err := m.chain.ReadAssertionCreationInfo(ctx, protocol.AssertionHash{Hash: creationInfo.ParentAssertionHash})
+	if err != nil {
+		srvlog.Error("Could not get assertion creation info by hash", log.Ctx{"err": err, "assertionHash": creationInfo.ParentAssertionHash})
+		return false
+	}
+	latestHeader, err := m.chain.Backend().HeaderByNumber(ctx, nil)
+	if err != nil {
+		srvlog.Error("Could not get latest header", log.Ctx{"err": err})
+		return false
+	}
+	if !latestHeader.Number.IsUint64() {
+		srvlog.Error("Latest block number is not a uint64", log.Ctx{"number": latestHeader.Number.String()})
+		return false
+	}
+	creationBlock := creationInfo.CreationBlock
+	confirmPeriodBlocks := prevCreationInfo.ConfirmPeriodBlocks
+	currentBlock := latestHeader.Number.Uint64()
+
+	// If the assertion is not yet confirmable, we can simply wait until we are confirmable by time.
+	if currentBlock < creationBlock+confirmPeriodBlocks {
+		blocksLeftForConfirmation := (creationBlock + confirmPeriodBlocks) - currentBlock
+		timeToWait := m.averageTimeForBlockCreation * time.Duration(blocksLeftForConfirmation)
+		<-time.After(timeToWait)
+	}
+
 	err = m.chain.ConfirmAssertionByTime(ctx, assertionHash)
 	if err != nil {
 		if strings.Contains(err.Error(), protocol.BeforeDeadlineAssertionConfirmationError) {
-			creationInfo, err := m.chain.ReadAssertionCreationInfo(ctx, assertionHash)
-			if err != nil {
-				srvlog.Error("Could not get assertion creation info by hash", log.Ctx{"err": err, "assertionHash": assertionHash.Hash})
-				return false
-			}
-			prevCreationInfo, err := m.chain.ReadAssertionCreationInfo(ctx, protocol.AssertionHash{Hash: creationInfo.ParentAssertionHash})
-			if err != nil {
-				srvlog.Error("Could not get assertion creation info by hash", log.Ctx{"err": err, "assertionHash": creationInfo.ParentAssertionHash})
-				return false
-			}
-			latestHeader, err := m.chain.Backend().HeaderByNumber(ctx, nil)
-			if err != nil {
-				srvlog.Error("Could not get latest header", log.Ctx{"err": err})
-				return false
-			}
-			<-time.After(m.getConfirmationInterval(creationInfo.CreationBlock, prevCreationInfo.ConfirmPeriodBlocks, latestHeader.Number.Uint64()))
+			return false
 		}
+		srvlog.Error("Could not confirm assertion by time", log.Ctx{"blockNumber": latestHeader.Number.String()})
 		return false
 	}
 	srvlog.Info("Assertion confirmed", log.Ctx{"assertionHash": assertionHash.Hash})
 	return true
-}
-
-func (m *Manager) getConfirmationInterval(creationBlock uint64, confirmPeriodBlocks uint64, latestHeaderNumber uint64) time.Duration {
-	if creationBlock+confirmPeriodBlocks > latestHeaderNumber {
-		blocksLeftForConfirmation := (creationBlock + confirmPeriodBlocks) - latestHeaderNumber
-		return m.averageTimeForBlockCreation * time.Duration(blocksLeftForConfirmation)
-	}
-	return 0
 }
 
 // Returns true if the manager can respond to an assertion with a challenge.

--- a/assertions/scanner.go
+++ b/assertions/scanner.go
@@ -17,6 +17,7 @@ import (
 
 	protocol "github.com/OffchainLabs/bold/chain-abstraction"
 	"github.com/OffchainLabs/bold/challenge-manager/types"
+	"github.com/OffchainLabs/bold/containers"
 	"github.com/OffchainLabs/bold/containers/option"
 	"github.com/OffchainLabs/bold/containers/threadsafe"
 	l2stateprovider "github.com/OffchainLabs/bold/layer2-state-provider"
@@ -530,6 +531,13 @@ func (m *Manager) assertionConfirmed(ctx context.Context, assertionHash protocol
 	if currentBlock < creationBlock+confirmPeriodBlocks {
 		blocksLeftForConfirmation := (creationBlock + confirmPeriodBlocks) - currentBlock
 		timeToWait := m.averageTimeForBlockCreation * time.Duration(blocksLeftForConfirmation)
+		srvlog.Info(
+			fmt.Sprintf(
+				"Assertion with has %s needs at least %d blocks before being confirmable, waiting until then",
+				containers.Trunc(creationInfo.AssertionHash.Bytes()),
+				blocksLeftForConfirmation,
+			),
+		)
 		<-time.After(timeToWait)
 	}
 

--- a/challenge-manager/challenge-tree/generalized_path_timer.go
+++ b/challenge-manager/challenge-tree/generalized_path_timer.go
@@ -18,6 +18,7 @@ var (
 	ErrNoHonestTopLevelEdge = errors.New("no honest block challenge edge being tracked")
 	ErrNotFound             = errors.New("not found in honest challenge tree")
 	ErrNoLevelZero          = errors.New("no level zero edge with origin id found")
+	ErrNoLowerChildYet      = errors.New("edge does not yet have a lower child")
 )
 
 // PathTimer for an honest edge defined as the cumulative unrivaled time
@@ -234,7 +235,7 @@ func (ht *HonestChallengeTree) findHonestAncestorsWithinChallengeLevel(
 				return nil, nil, errors.Wrapf(lowerErr, "could not get lower child for edge %#x", cursor.Id())
 			}
 			if lowerChild.IsNone() {
-				return nil, nil, fmt.Errorf("edge %#x had no lower child", cursor.Id())
+				return nil, nil, errors.Wrapf(ErrNoLowerChildYet, "edge id %#x", cursor.Id())
 			}
 			cursor = ht.edges.Get(lowerChild.Unwrap())
 		} else {

--- a/challenge-manager/manager.go
+++ b/challenge-manager/manager.go
@@ -159,7 +159,7 @@ func New(
 		assertionPostingInterval:    time.Hour,
 		assertionScanningInterval:   time.Minute,
 		assertionConfirmingInterval: time.Second * 10,
-		averageTimeForBlockCreation: time.Millisecond * 500,
+		averageTimeForBlockCreation: time.Second * 12,
 		challengedAssertions:        threadsafe.NewSet[protocol.AssertionHash](),
 	}
 	for _, o := range opts {


### PR DESCRIPTION
This PR improves some of the most common error logs that occur when running a BOLD challenge on testnet. It makes the following changes:

- We try to confirm an assertion by time, and if it fails, we then wait some specified amount of time before retrying. However, this leads to execution revert logs. Instead, we should make this onchain tx only if the assertion is confirmable by time
- If an edge does not have a lower child when computing timers, we shouldn't necessarily error. Instead, most of the time this error happens is because we have not yet processed the child creation event, which some other validator may have created. We turn it into an info log
- We log how long an assertion has to wait before it is confirmable by time
- We change a wrong `avgTimeForBlockCreation` default value from 500ms to 12s on Ethereum chains