### PR TITLE
Updated path timer to check claim id rather than prev

### DIFF
--- a/challenge-manager/chain-watcher/watcher_test.go
+++ b/challenge-manager/chain-watcher/watcher_test.go
@@ -183,10 +183,11 @@ func TestWatcher_processEdgeAddedEvent(t *testing.T) {
 	mockManager.On("TrackEdge", ctx, edge).Return(nil)
 
 	watcher := &Watcher{
-		challenges:  threadsafe.NewMap[protocol.AssertionHash, *trackedChallenge](),
-		histChecker: mockStateManager,
-		chain:       mockChain,
-		edgeManager: mockManager,
+		challenges:       threadsafe.NewMap[protocol.AssertionHash, *trackedChallenge](),
+		histChecker:      mockStateManager,
+		chain:            mockChain,
+		edgeManager:      mockManager,
+		numBigStepLevels: 1,
 	}
 	err := watcher.processEdgeAddedEvent(ctx, &challengeV2gen.EdgeChallengeManagerEdgeAdded{
 		EdgeId:   edgeId.Hash,
@@ -249,10 +250,11 @@ func TestWatcher_AddVerifiedHonestEdge(t *testing.T) {
 	mockManager.On("TrackEdge", ctx, honest).Return(nil)
 
 	watcher := &Watcher{
-		challenges:  threadsafe.NewMap[protocol.AssertionHash, *trackedChallenge](),
-		histChecker: mockStateManager,
-		chain:       mockChain,
-		edgeManager: mockManager,
+		challenges:       threadsafe.NewMap[protocol.AssertionHash, *trackedChallenge](),
+		histChecker:      mockStateManager,
+		chain:            mockChain,
+		edgeManager:      mockManager,
+		numBigStepLevels: 1,
 	}
 
 	err := watcher.AddVerifiedHonestEdge(ctx, honest)

--- a/challenge-manager/challenge-tree/ancestors_test.go
+++ b/challenge-manager/challenge-tree/ancestors_test.go
@@ -63,11 +63,11 @@ func buildEdges(allEdges ...*mock.Edge) map[mock.EdgeId]*mock.Edge {
 //	      \--5'--6'----8'----------16' = Bob
 //
 // and then inserts the respective edges into a challenge tree.
-func setupBlockChallengeTreeSnapshot(t *testing.T, tree *HonestChallengeTree) {
+func setupBlockChallengeTreeSnapshot(t *testing.T, tree *HonestChallengeTree, claimId string) {
 	t.Helper()
 	aliceEdges := buildEdges(
 		// Alice.
-		newEdge(&newCfg{t: t, edgeId: "blk-0.a-16.a", createdAt: 1}),
+		newEdge(&newCfg{t: t, edgeId: "blk-0.a-16.a", claimId: claimId, createdAt: 1}),
 		newEdge(&newCfg{t: t, edgeId: "blk-0.a-8.a", createdAt: 3}),
 		newEdge(&newCfg{t: t, edgeId: "blk-8.a-16.a", createdAt: 3}),
 		newEdge(&newCfg{t: t, edgeId: "blk-0.a-4.a", createdAt: 5}),

--- a/challenge-manager/challenge-tree/generalized_path_timer.go
+++ b/challenge-manager/challenge-tree/generalized_path_timer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/OffchainLabs/bold/containers"
 	"github.com/OffchainLabs/bold/containers/threadsafe"
 	bisection "github.com/OffchainLabs/bold/math"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
 )
 
@@ -57,8 +58,17 @@ func (ht *HonestChallengeTree) HasConfirmableAncestor(
 	if len(honestAncestorLocalTimers) == 0 {
 		return false, nil
 	}
+
+	blockRootEdge, err := ht.HonestBlockChallengeRootEdge()
+	if err != nil {
+		return false, err
+	}
+	if blockRootEdge.ClaimId().IsNone() {
+		return false, fmt.Errorf("expected claimId to be found on block level root edge %#x", blockRootEdge.Id())
+	}
+
 	assertionUnrivaledNumBlocks, err := ht.metadataReader.AssertionUnrivaledBlocks(
-		ctx, ht.topLevelAssertionHash,
+		ctx, protocol.AssertionHash{Hash: common.Hash(blockRootEdge.ClaimId().Unwrap())},
 	)
 	if err != nil {
 		return false, err
@@ -91,8 +101,17 @@ func (ht *HonestChallengeTree) ComputeHonestPathTimer(
 		return 0, err
 	}
 	total := PathTimer(edgeLocalTimer)
+
+	blockRootEdge, err := ht.HonestBlockChallengeRootEdge()
+	if err != nil {
+		return 0, err
+	}
+	if blockRootEdge.ClaimId().IsNone() {
+		return 0, fmt.Errorf("expected claimId to be found on block level root edge %#x", blockRootEdge.Id())
+	}
+
 	assertionUnrivaledTimer, err := ht.metadataReader.AssertionUnrivaledBlocks(
-		ctx, ht.topLevelAssertionHash,
+		ctx, protocol.AssertionHash{Hash: common.Hash(blockRootEdge.ClaimId().Unwrap())},
 	)
 	if err != nil {
 		return 0, err

--- a/challenge-manager/challenge-tree/generalized_path_timer.go
+++ b/challenge-manager/challenge-tree/generalized_path_timer.go
@@ -107,7 +107,7 @@ func (ht *HonestChallengeTree) ComputeHonestPathTimer(
 		return 0, err
 	}
 	if blockRootEdge.ClaimId().IsNone() {
-		return 0, fmt.Errorf("expected claimId to be found on block level root edge %#x", blockRootEdge.Id())
+		return 0, fmt.Errorf("expected claimId to be found on block level root edge when computing honest path timer %#x", blockRootEdge.Id())
 	}
 
 	assertionUnrivaledTimer, err := ht.metadataReader.AssertionUnrivaledBlocks(


### PR DESCRIPTION
Previously when calculating the path timer we were including the unrivaled time of the prev assertion, we should instead be using the unrivaled time of the claimed assertion. This lead to some instances where it appeared an edge could be confirmed when in fact it couldnt.