### PR TITLE
Add In-Progress Cache for Expensive Computation

### DIFF
--- a/containers/in-progress-cache/BUILD.bazel
+++ b/containers/in-progress-cache/BUILD.bazel
@@ -5,6 +5,10 @@ go_library(
     srcs = ["cache.go"],
     importpath = "github.com/OffchainLabs/bold/containers/in-progress-cache",
     visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_prometheus_client_golang//prometheus",
+        "@com_github_prometheus_client_golang//prometheus/promauto",
+    ],
 )
 
 go_test(

--- a/containers/in-progress-cache/BUILD.bazel
+++ b/containers/in-progress-cache/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "in-progress-cache",
+    srcs = ["cache.go"],
+    importpath = "github.com/OffchainLabs/bold/containers/in-progress-cache",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "in-progress-cache_test",
+    srcs = ["cache_test.go"],
+    embed = [":in-progress-cache"],
+)

--- a/containers/in-progress-cache/cache.go
+++ b/containers/in-progress-cache/cache.go
@@ -1,6 +1,29 @@
 package inprogresscache
 
-import "sync"
+import (
+	"fmt"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	inFlightRequestsCounter = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "inprogresscache_in_flight_requests_total",
+			Help: "Total number of in-flight requests.",
+		},
+		[]string{"requestId"},
+	)
+	pendingRequestsCounter = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "inprogresscache_pending_requests_total",
+			Help: "Total number of pending requests received while a request with the same ID was in-flight.",
+		},
+		[]string{"requestId"},
+	)
+)
 
 // Cache for expensive computations that ensures only
 // one request is in-flight at a time. If a future request comes in with the same request id
@@ -23,6 +46,8 @@ func New[K comparable, V any]() *Cache[K, V] {
 func (c *Cache[K, V]) Compute(requestId K, f func() (V, error)) (V, error) {
 	c.lock.RLock()
 	if ok := c.inProgress[requestId]; ok {
+		pendingRequestsCounter.WithLabelValues(fmt.Sprintf("%v", requestId)).Inc()
+
 		c.lock.RUnlock()
 		responseChan := make(chan V, 1)
 		defer close(responseChan)
@@ -45,6 +70,8 @@ func (c *Cache[K, V]) Compute(requestId K, f func() (V, error)) (V, error) {
 	if err != nil {
 		return zeroVal, err
 	}
+
+	inFlightRequestsCounter.WithLabelValues(fmt.Sprintf("%v", requestId)).Inc()
 
 	c.lock.RLock()
 	receiversWaiting, ok := c.awaitingCompletion[requestId]

--- a/containers/in-progress-cache/cache.go
+++ b/containers/in-progress-cache/cache.go
@@ -19,7 +19,7 @@ func New[K comparable, V any]() *InProgressCache[K, V] {
 	}
 }
 
-// Compute an expensive closure. The request must be representable as a string.
+// Compute an expensive closure. The request must be representable as a comparable.
 func (c *InProgressCache[K, V]) Compute(requestId K, f func() (V, error)) (V, error) {
 	c.lock.RLock()
 	if ok := c.inProgress[requestId]; ok {

--- a/containers/in-progress-cache/cache.go
+++ b/containers/in-progress-cache/cache.go
@@ -1,0 +1,64 @@
+package inprogresscache
+
+import "sync"
+
+// InProgressCache implements a cache for expensive computations that ensures only
+// one request is in-flight at a time. If a future request comes in with the same request id
+// as the ongoing computation, a goroutine is spawned that awaits the computation's completion
+// instead of kicking off two expensive computations.
+type InProgressCache[K comparable, V any] struct {
+	inProgress         map[K]bool
+	awaitingCompletion map[K][]chan V
+	lock               sync.RWMutex
+}
+
+func New[K comparable, V any]() *InProgressCache[K, V] {
+	return &InProgressCache[K, V]{
+		inProgress:         make(map[K]bool),
+		awaitingCompletion: make(map[K][]chan V),
+	}
+}
+
+// Compute an expensive closure. The request must be representable as a string.
+func (c *InProgressCache[K, V]) Compute(requestId K, f func() (V, error)) (V, error) {
+	c.lock.RLock()
+	if ok := c.inProgress[requestId]; ok {
+		c.lock.RUnlock()
+		responseChan := make(chan V, 1)
+		defer close(responseChan)
+
+		c.lock.Lock()
+		c.awaitingCompletion[requestId] = append(c.awaitingCompletion[requestId], responseChan)
+		c.lock.Unlock()
+		val := <-responseChan
+		return val, nil
+	}
+	c.lock.RUnlock()
+
+	c.lock.Lock()
+	c.inProgress[requestId] = true
+	c.lock.Unlock()
+
+	// Do expensive operation
+	var zeroVal V
+	result, err := f()
+	if err != nil {
+		return zeroVal, err
+	}
+
+	c.lock.RLock()
+	receiversWaiting, ok := c.awaitingCompletion[requestId]
+	c.lock.RUnlock()
+
+	if ok {
+		for _, ch := range receiversWaiting {
+			ch <- result
+		}
+	}
+
+	c.lock.Lock()
+	c.inProgress[requestId] = false
+	c.awaitingCompletion[requestId] = make([]chan V, 0)
+	c.lock.Unlock()
+	return result, nil
+}

--- a/containers/in-progress-cache/cache.go
+++ b/containers/in-progress-cache/cache.go
@@ -2,25 +2,25 @@ package inprogresscache
 
 import "sync"
 
-// InProgressCache implements a cache for expensive computations that ensures only
+// Cache for expensive computations that ensures only
 // one request is in-flight at a time. If a future request comes in with the same request id
 // as the ongoing computation, a goroutine is spawned that awaits the computation's completion
 // instead of kicking off two expensive computations.
-type InProgressCache[K comparable, V any] struct {
+type Cache[K comparable, V any] struct {
 	inProgress         map[K]bool
 	awaitingCompletion map[K][]chan V
 	lock               sync.RWMutex
 }
 
-func New[K comparable, V any]() *InProgressCache[K, V] {
-	return &InProgressCache[K, V]{
+func New[K comparable, V any]() *Cache[K, V] {
+	return &Cache[K, V]{
 		inProgress:         make(map[K]bool),
 		awaitingCompletion: make(map[K][]chan V),
 	}
 }
 
-// Compute an expensive closure. The request must be representable as a comparable.
-func (c *InProgressCache[K, V]) Compute(requestId K, f func() (V, error)) (V, error) {
+// Compute an expensive closure. The request must be representable as a string.
+func (c *Cache[K, V]) Compute(requestId K, f func() (V, error)) (V, error) {
 	c.lock.RLock()
 	if ok := c.inProgress[requestId]; ok {
 		c.lock.RUnlock()

--- a/containers/in-progress-cache/cache_test.go
+++ b/containers/in-progress-cache/cache_test.go
@@ -53,7 +53,9 @@ func TestConcurrentComputations(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			cache.Compute(requestId, computeFunc)
+			if _, err := cache.Compute(requestId, computeFunc); err != nil {
+				t.Error(err)
+			}
 		}()
 	}
 	wg.Wait()

--- a/containers/in-progress-cache/cache_test.go
+++ b/containers/in-progress-cache/cache_test.go
@@ -1,0 +1,65 @@
+package inprogresscache
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestCompute(t *testing.T) {
+	cache := New[string, int]()
+	requestId := "testRequest"
+
+	// Define a computation function
+	computeFunc := func() (int, error) {
+		time.Sleep(100 * time.Millisecond)
+		return 42, nil
+	}
+
+	// Call Compute and check the result
+	result, err := cache.Compute(requestId, computeFunc)
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if result != 42 {
+		t.Errorf("Expected result to be 42, got %d", result)
+	}
+
+	// Call Compute again with the same requestId and ensure the cached value is returned
+	cachedResult, cachedErr := cache.Compute(requestId, computeFunc)
+	if cachedErr != nil {
+		t.Errorf("Expected no error from cached result, got %v", cachedErr)
+	}
+	if cachedResult != result {
+		t.Errorf("Expected cached result to be %d, got %d", result, cachedResult)
+	}
+}
+
+// TestConcurrentComputations tests that concurrent calls to Compute with the same request ID
+// only result in a single computation.
+func TestConcurrentComputations(t *testing.T) {
+	cache := New[string, int]()
+	requestId := "concurrentTest"
+	counter := 0
+
+	computeFunc := func() (int, error) {
+		time.Sleep(100 * time.Millisecond)
+		counter++
+		return counter, nil
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cache.Compute(requestId, computeFunc)
+		}()
+	}
+	wg.Wait()
+
+	// Verify that the computation was only performed once
+	if counter != 1 {
+		t.Errorf("Expected a single computation, got %d", counter)
+	}
+}

--- a/containers/in-progress-cache/cache_test.go
+++ b/containers/in-progress-cache/cache_test.go
@@ -51,10 +51,13 @@ func TestConcurrentComputations(t *testing.T) {
 	var wg sync.WaitGroup
 	for i := 0; i < 20; i++ {
 		wg.Add(1)
-		go func() {
+		go func(tt *testing.T) {
 			defer wg.Done()
-			cache.Compute(requestId, computeFunc)
-		}()
+			_, err := cache.Compute(requestId, computeFunc)
+			if err != nil {
+				t.Error("Failed compute")
+			}
+		}(t)
 	}
 	wg.Wait()
 

--- a/containers/in-progress-cache/cache_test.go
+++ b/containers/in-progress-cache/cache_test.go
@@ -51,13 +51,10 @@ func TestConcurrentComputations(t *testing.T) {
 	var wg sync.WaitGroup
 	for i := 0; i < 20; i++ {
 		wg.Add(1)
-		go func(tt *testing.T) {
+		go func() {
 			defer wg.Done()
-			_, err := cache.Compute(requestId, computeFunc)
-			if err != nil {
-				t.Error("Failed compute")
-			}
-		}(t)
+			cache.Compute(requestId, computeFunc)
+		}()
 	}
 	wg.Wait()
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/mattn/go-sqlite3 v1.14.6
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.14.0
 	github.com/stretchr/testify v1.8.2
 	golang.org/x/sync v0.1.0
 )
@@ -47,7 +48,6 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.39.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect

--- a/layer2-state-provider/BUILD.bazel
+++ b/layer2-state-provider/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//chain-abstraction:protocol",
+        "//containers/in-progress-cache",
         "//containers/option",
         "//state-commitments/history",
         "//state-commitments/prefix-proofs",

--- a/layer2-state-provider/history_commitment_provider.go
+++ b/layer2-state-provider/history_commitment_provider.go
@@ -75,7 +75,6 @@ func (h *HashCollectorConfig) String() string {
 	str += fmt.Sprintf("%d", h.MachineStartIndex)
 	str += "/"
 	str += fmt.Sprintf("%d", h.StepSize)
-	str += "/"
 	return ""
 }
 

--- a/layer2-state-provider/history_commitment_provider.go
+++ b/layer2-state-provider/history_commitment_provider.go
@@ -75,7 +75,7 @@ func (h *HashCollectorConfig) String() string {
 	str += fmt.Sprintf("%d", h.MachineStartIndex)
 	str += "/"
 	str += fmt.Sprintf("%d", h.StepSize)
-	return ""
+	return str
 }
 
 // L2MessageStateCollector defines an interface which can obtain the machine hashes at each L2 message

--- a/layer2-state-provider/history_commitment_provider.go
+++ b/layer2-state-provider/history_commitment_provider.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 
 	protocol "github.com/OffchainLabs/bold/chain-abstraction"
+	inprogresscache "github.com/OffchainLabs/bold/containers/in-progress-cache"
 	prefixproofs "github.com/OffchainLabs/bold/state-commitments/prefix-proofs"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 
@@ -57,6 +58,27 @@ type HashCollectorConfig struct {
 	StepSize StepSize
 }
 
+func (h *HashCollectorConfig) String() string {
+	str := ""
+	str += h.WasmModuleRoot.String()
+	str += "/"
+	str += fmt.Sprintf("%d", h.FromBatch)
+	str += "/"
+	str += fmt.Sprintf("%d", h.BlockChallengeHeight)
+	str += "/"
+	for _, height := range h.StepHeights {
+		str += fmt.Sprintf("%d", height)
+		str += "/"
+	}
+	str += fmt.Sprintf("%d", h.NumDesiredHashes)
+	str += "/"
+	str += fmt.Sprintf("%d", h.MachineStartIndex)
+	str += "/"
+	str += fmt.Sprintf("%d", h.StepSize)
+	str += "/"
+	return ""
+}
+
 // L2MessageStateCollector defines an interface which can obtain the machine hashes at each L2 message
 // in a specified message range for a given batch index on Arbitrum.
 type L2MessageStateCollector interface {
@@ -77,6 +99,7 @@ type HistoryCommitmentProvider struct {
 	machineHashCollector    MachineHashCollector
 	proofCollector          ProofCollector
 	challengeLeafHeights    []Height
+	inFlightRequestCache    *inprogresscache.Cache[string, []common.Hash]
 	ExecutionProvider
 }
 
@@ -95,6 +118,7 @@ func NewHistoryCommitmentProvider(
 		proofCollector:          proofCollector,
 		challengeLeafHeights:    challengeLeafHeights,
 		ExecutionProvider:       executionProvider,
+		inFlightRequestCache:    inprogresscache.New[string, []common.Hash](),
 	}
 }
 
@@ -167,21 +191,24 @@ func (p *HistoryCommitmentProvider) historyCommitmentImpl(
 	}
 
 	// Collect the machine hashes at the specified challenge level based on the values we computed.
-	return p.machineHashCollector.CollectMachineHashes(
-		ctx,
-		&HashCollectorConfig{
-			WasmModuleRoot:       req.WasmModuleRoot,
-			FromBatch:            req.FromBatch,
-			BlockChallengeHeight: fromBlockChallengeHeight,
-			// We drop the first index of the validated heights, because the first index is for the block challenge level,
-			// which is over blocks and not over individual machine WASM opcodes. Starting from the second index, we are now
-			// dealing with challenges over ranges of opcodes which are what we care about for our implementation of machine hash collection.
-			StepHeights:       validatedHeights[1:],
-			NumDesiredHashes:  numHashes,
-			MachineStartIndex: machineStartIndex,
-			StepSize:          stepSize,
-		},
-	)
+	cfg := &HashCollectorConfig{
+		WasmModuleRoot:       req.WasmModuleRoot,
+		FromBatch:            req.FromBatch,
+		BlockChallengeHeight: fromBlockChallengeHeight,
+		// We drop the first index of the validated heights, because the first index is for the block challenge level,
+		// which is over blocks and not over individual machine WASM opcodes. Starting from the second index, we are now
+		// dealing with challenges over ranges of opcodes which are what we care about for our implementation of machine hash collection.
+		StepHeights:       validatedHeights[1:],
+		NumDesiredHashes:  numHashes,
+		MachineStartIndex: machineStartIndex,
+		StepSize:          stepSize,
+	}
+	// Requests collecting machine hashes for the specified config, and uses an in-flight
+	// request cache to make sure the same request is not spawned twice, but rather
+	// the second request would wait for the in-flight request to complete and use its result.
+	return p.inFlightRequestCache.Compute(cfg.String(), func() ([]common.Hash, error) {
+		return p.machineHashCollector.CollectMachineHashes(ctx, cfg)
+	})
 }
 
 // AgreesWithHistoryCommitment checks if the l2 state provider agrees with a specified start and end


### PR DESCRIPTION
In BOLD, when interacting with a state provider, we make very expensive computational requests. Sometimes, we may end up making the same request twice as BOLD has several places that process data concurrently.

One example is in computing subchallenges, which is a very expensive computation that can last hours. If an in-flight request is being computed, and another is requested for the same data, we want to use the result of the ongoing one instead of spawning a new computation. This PR adds an "in-progress cache" generic container that leverages this idea. Inspired by https://rauljordan.com/reuse-expensive-computation-with-in-progress-caches/

```go
type InProgressCache[K comparable, V any] struct

// Compute an expensive closure, and if the same request is used to the cache while one is in-progress, we await
// the completion of the in-flight request instead of spawning a new one
func (c *InProgressCache[K, V]) Compute(requestId K, f func() (V, error)) (V, error)
```