### PR TITLE
Despawn Edge if Challenged Assertion Confirmed

### DIFF
--- a/challenge-manager/edge-tracker/tracker.go
+++ b/challenge-manager/edge-tracker/tracker.go
@@ -367,6 +367,16 @@ func (et *Tracker) ShouldDespawn(ctx context.Context) bool {
 		srvlog.Error("Could not get assertion hash", fields)
 		return false
 	}
+	assertionStatus, err := et.chain.AssertionStatus(ctx, assertionHash)
+	if err != nil {
+		fields["err"] = err
+		srvlog.Error("Could not check assertion status", fields)
+		return false
+	}
+	if assertionStatus == protocol.AssertionConfirmed {
+		srvlog.Info("Challenged assertion corresponding to edge was confirmed, exiting", fields)
+		return true
+	}
 	_, _, ancestorLocalTimers, err := et.chainWatcher.ComputeHonestPathTimer(ctx, assertionHash, et.edge.Id())
 	if err != nil {
 		if errors.Is(err, challengetree.ErrNoLowerChildYet) {


### PR DESCRIPTION
When an edge checks if its edge tracker goroutine should despawn, we should also check if the source assertion of the challenge was confirmed. If so, we can exit safely.