### PR TITLE
Fix addBlockChallengeLevelZeroEdge return value

### DIFF
--- a/challenge-manager/challenges.go
+++ b/challenge-manager/challenges.go
@@ -172,5 +172,5 @@ func (m *Manager) addBlockChallengeLevelZeroEdge(
 		FromBatch:      fromBatch,
 		ToBatch:        toBatch,
 		WasmModuleRoot: prevCreationInfo.WasmModuleRoot,
-	}, true, nil
+	}, false, nil
 }


### PR DESCRIPTION
This was causing the issue of Block challenge, root edge not found in API