### PR TITLE
Added time unrivaled caching

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -4,5 +4,5 @@ out = 'out'
 libs = ['lib']
 solc = '0.8.17'
 optimizer = true
-optimizer_runs = 2000
+optimizer_runs = 500    
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -4,5 +4,5 @@ out = 'out'
 libs = ['lib']
 solc = '0.8.17'
 optimizer = true
-optimizer_runs = 500    
+optimizer_runs = 500
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/contracts/src/challengeV2/libraries/ChallengeEdgeLib.sol
+++ b/contracts/src/challengeV2/libraries/ChallengeEdgeLib.sol
@@ -49,6 +49,8 @@ struct ChallengeEdge {
     /// @notice The block number at which this edge was confirmed
     ///         Zero if not confirmed
     uint64 confirmedAtBlock;
+    /// CHRIS: TODO
+    uint64 ancestryTimeUnrivaled;
     /// @notice Current status of this edge. All edges are created Pending, and may be updated to Confirmed
     ///         Once Confirmed they cannot transition back to Pending
     EdgeStatus status;
@@ -116,6 +118,7 @@ library ChallengeEdgeLib {
             lowerChildId: 0,
             upperChildId: 0,
             createdAtBlock: uint64(block.number),
+            ancestryTimeUnrivaled: 0,
             claimId: claimId,
             staker: staker,
             status: EdgeStatus.Pending,
@@ -146,6 +149,7 @@ library ChallengeEdgeLib {
             lowerChildId: 0,
             upperChildId: 0,
             createdAtBlock: uint64(block.number),
+            ancestryTimeUnrivaled: 0,
             claimId: 0,
             staker: address(0),
             status: EdgeStatus.Pending,
@@ -281,6 +285,13 @@ library ChallengeEdgeLib {
             return EdgeType.SmallStep;
         } else {
             revert LevelTooHigh(level, numBigStepLevels);
+        }
+    }
+
+    // CHRIS: TODO: only update is >. docs
+    function updateAncestryTimeUnrivaled(ChallengeEdge storage edge, uint64 newAncestryTimeUnrivaled) internal {
+        if(newAncestryTimeUnrivaled > edge.ancestryTimeUnrivaled) {
+            edge.ancestryTimeUnrivaled = newAncestryTimeUnrivaled;
         }
     }
 }

--- a/contracts/src/challengeV2/libraries/EdgeChallengeManagerLib.sol
+++ b/contracts/src/challengeV2/libraries/EdgeChallengeManagerLib.sol
@@ -778,7 +778,7 @@ library EdgeChallengeManagerLib {
                 } 
 
                 // when moving between levels we record how much time had been accumulated up to that point
-                accumulatedTimeByLevel[e.level - 1] = AccumulatedTime({edgeId: ancestorEdgeIds[i], time: totalTimeUnrivaled});
+                accumulatedTimeByLevel[store.edges[currentEdgeId].level - 1] = AccumulatedTime({edgeId: ancestorEdgeIds[i], time: totalTimeUnrivaled});
                 totalTimeUnrivaled += timeUnrivaled(store, e.id());
                 currentEdgeId = ancestorEdgeIds[i];
             } else {

--- a/contracts/src/challengeV2/libraries/EdgeChallengeManagerLib.sol
+++ b/contracts/src/challengeV2/libraries/EdgeChallengeManagerLib.sol
@@ -797,7 +797,7 @@ library EdgeChallengeManagerLib {
         }
 
         // update new cached items
-        for (uint8 level = 0; level < accumulatedTimeByLevel.length; level++) {
+        for (uint256 level = 0; level < accumulatedTimeByLevel.length; level++) {
             if(accumulatedTimeByLevel[level].edgeId != 0) {
                 uint64 timeUnrivaledAtLevel = totalTimeUnrivaled - accumulatedTimeByLevel[level].time;
                 // update the sum time unrivaled

--- a/contracts/src/challengeV2/libraries/EdgeChallengeManagerLib.sol
+++ b/contracts/src/challengeV2/libraries/EdgeChallengeManagerLib.sol
@@ -778,7 +778,7 @@ library EdgeChallengeManagerLib {
                 } 
 
                 // when moving between levels we record how much time had been accumulated up to that point
-                accumulatedTimeByLevel[store.edges[currentEdgeId].level - 1] = AccumulatedTime({edgeId: ancestorEdgeIds[i], time: totalTimeUnrivaled});
+                accumulatedTimeByLevel[e.level - 1] = AccumulatedTime({edgeId: ancestorEdgeIds[i], time: totalTimeUnrivaled});
                 totalTimeUnrivaled += timeUnrivaled(store, e.id());
                 currentEdgeId = ancestorEdgeIds[i];
             } else {

--- a/contracts/test/challengeV2/ChallengeEdgeLib.t.sol
+++ b/contracts/test/challengeV2/ChallengeEdgeLib.t.sol
@@ -15,7 +15,7 @@ contract TestChallengeEdge {
 }
 
 contract ChallengeEdgeLibAccess {
-    ChallengeEdge public storageEdge;
+    ChallengeEdge internal storageEdge;
 
     function getChallengeEdge() public returns (ChallengeEdge memory) {
         return storageEdge;


### PR DESCRIPTION
Simple caching that requires no changes in the validator. Can reduce the gas costs of `confirmEdgeByTime` by O(1/L) where L is the number of levels in the challenge.

As an example this confirm used 1M gas: https://sepolia.etherscan.io/tx/0x9b912f60b42015f50d452fa74147c3d3163321866c7098765aea4953dd360fb3
With this PR i would expect it to use around 350k or less.

We can also adapt this caching to cache not once per level, but once per N bisections. Updating the cache costs gas, but having it more frequent is more efficient when confirming, so there is a tradeoff there.