### PR TITLE
Show a Tracked Edge's Finite State Machine in API Results

### DIFF
--- a/api/backend/BUILD.bazel
+++ b/api/backend/BUILD.bazel
@@ -10,6 +10,8 @@ go_library(
         "//api/db",
         "//chain-abstraction:protocol",
         "//challenge-manager/chain-watcher",
+        "//challenge-manager/edge-tracker",
+        "//containers/option",
         "@com_github_ethereum_go_ethereum//common",
         "@com_github_ethereum_go_ethereum//common/hexutil",
         "@com_github_pkg_errors//:errors",

--- a/api/backend/backend.go
+++ b/api/backend/backend.go
@@ -13,6 +13,8 @@ import (
 	"github.com/OffchainLabs/bold/api/db"
 	protocol "github.com/OffchainLabs/bold/chain-abstraction"
 	watcher "github.com/OffchainLabs/bold/challenge-manager/chain-watcher"
+	edgetracker "github.com/OffchainLabs/bold/challenge-manager/edge-tracker"
+	"github.com/OffchainLabs/bold/containers/option"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
@@ -26,21 +28,28 @@ type BusinessLogicProvider interface {
 	LatestConfirmedAssertion(ctx context.Context) (*api.JsonAssertion, error)
 }
 
+type EdgeTrackerFetcher interface {
+	GetEdgeTracker(edgeId protocol.EdgeId) option.Option[*edgetracker.Tracker]
+}
+
 type Backend struct {
 	db               db.ReadUpdateDatabase
 	chainDataFetcher protocol.AssertionChain
 	chainWatcher     *watcher.Watcher
+	trackerFetcher   EdgeTrackerFetcher
 }
 
 func NewBackend(
 	db db.ReadUpdateDatabase,
 	chainDataFetcher protocol.AssertionChain,
 	chainWatcher *watcher.Watcher,
+	trackerFetcher EdgeTrackerFetcher,
 ) *Backend {
 	return &Backend{
 		db:               db,
 		chainDataFetcher: chainDataFetcher,
 		chainWatcher:     chainWatcher,
+		trackerFetcher:   trackerFetcher,
 	}
 }
 
@@ -172,6 +181,14 @@ func (b *Backend) GetEdges(ctx context.Context, opts ...db.EdgeOption) ([]*api.J
 				e.CumulativePathTimer = uint64(pathTimer)
 			}
 			e.IsRoyal = isRoyal
+			trackerOpt := b.trackerFetcher.GetEdgeTracker(edge.Id())
+			if trackerOpt.IsSome() {
+				fsmState := trackerOpt.Unwrap().FSMSummary()
+				e.FSMState = fsmState.CurrentState
+				if fsmState.Error != nil {
+					e.FSMError = fsmState.Error.Error()
+				}
+			}
 		}
 		if err := b.db.UpdateEdges(edges); err != nil {
 			return nil, err

--- a/api/types.go
+++ b/api/types.go
@@ -63,6 +63,8 @@ type JsonEdge struct {
 	IsRoyal             bool          `json:"isRoyal" db:"IsRoyal"`
 	CumulativePathTimer uint64        `json:"cumulativePathTimer" db:"CumulativePathTimer"`
 	RefersTo            string        `json:"refersTo" db:"RefersTo"`
+	FSMState            string        `json:"fsmState"`
+	FSMError            string        `json:"fsmError"`
 }
 
 type JsonTrackedRoyalEdge struct {

--- a/challenge-manager/manager.go
+++ b/challenge-manager/manager.go
@@ -21,6 +21,7 @@ import (
 	watcher "github.com/OffchainLabs/bold/challenge-manager/chain-watcher"
 	edgetracker "github.com/OffchainLabs/bold/challenge-manager/edge-tracker"
 	"github.com/OffchainLabs/bold/challenge-manager/types"
+	"github.com/OffchainLabs/bold/containers/option"
 	"github.com/OffchainLabs/bold/containers/threadsafe"
 	l2stateprovider "github.com/OffchainLabs/bold/layer2-state-provider"
 	retry "github.com/OffchainLabs/bold/runtime"
@@ -222,7 +223,7 @@ func New(
 	m.watcher = watcher
 
 	if m.apiAddr != "" {
-		bknd := apibackend.NewBackend(m.apiDB, m.chain, m.watcher)
+		bknd := apibackend.NewBackend(m.apiDB, m.chain, m.watcher, m)
 		srv, err2 := server.New(m.apiAddr, bknd)
 		if err2 != nil {
 			return nil, err2
@@ -249,6 +250,13 @@ func New(
 	}
 	m.assertionManager = assertionManager
 	return m, nil
+}
+
+func (m *Manager) GetEdgeTracker(edgeId protocol.EdgeId) option.Option[*edgetracker.Tracker] {
+	if m.IsTrackingEdge(edgeId) {
+		return option.Some(m.trackedEdgeIds.Get(edgeId))
+	}
+	return option.None[*edgetracker.Tracker]()
 }
 
 // IsTrackingEdge returns true if we are currently tracking a specified edge id as an edge tracker goroutine.

--- a/challenge-manager/manager.go
+++ b/challenge-manager/manager.go
@@ -61,7 +61,7 @@ type Manager struct {
 	edgeTrackerWakeInterval     time.Duration
 	chainWatcherInterval        time.Duration
 	watcher                     *watcher.Watcher
-	trackedEdgeIds              *threadsafe.Set[protocol.EdgeId]
+	trackedEdgeIds              *threadsafe.Map[protocol.EdgeId, *edgetracker.Tracker]
 	batchIndexForAssertionCache *threadsafe.Map[protocol.AssertionHash, edgetracker.AssociatedAssertionMetadata]
 	assertionManager            *assertions.Manager
 	assertionPostingInterval    time.Duration
@@ -158,7 +158,7 @@ func New(
 		timeRef:                     utilTime.NewRealTimeReference(),
 		rollupAddr:                  rollupAddr,
 		chainWatcherInterval:        time.Millisecond * 500,
-		trackedEdgeIds:              threadsafe.NewSet[protocol.EdgeId](threadsafe.SetWithMetric[protocol.EdgeId]("trackedEdgeIds")),
+		trackedEdgeIds:              threadsafe.NewMap[protocol.EdgeId, *edgetracker.Tracker](threadsafe.MapWithMetric[protocol.EdgeId, *edgetracker.Tracker]("trackedEdgeIds")),
 		batchIndexForAssertionCache: threadsafe.NewMap[protocol.AssertionHash, edgetracker.AssociatedAssertionMetadata](threadsafe.MapWithMetric[protocol.AssertionHash, edgetracker.AssociatedAssertionMetadata]("batchIndexForAssertionCache")),
 		assertionPostingInterval:    time.Hour,
 		assertionScanningInterval:   time.Minute,
@@ -257,8 +257,8 @@ func (m *Manager) IsTrackingEdge(edgeId protocol.EdgeId) bool {
 }
 
 // MarkTrackedEdge marks an edge id as being tracked by our challenge manager.
-func (m *Manager) MarkTrackedEdge(edgeId protocol.EdgeId) {
-	m.trackedEdgeIds.Insert(edgeId)
+func (m *Manager) MarkTrackedEdge(edgeId protocol.EdgeId, tracker *edgetracker.Tracker) {
+	m.trackedEdgeIds.Put(edgeId, tracker)
 }
 
 // Mode returns the mode of the challenge manager.

--- a/testing/endtoend/e2e_test.go
+++ b/testing/endtoend/e2e_test.go
@@ -267,7 +267,6 @@ func runEndToEndTest(t *testing.T, cfg *e2eConfig) {
 		baseChallengeManagerOpts,
 		challengemanager.WithAddress(txOpts.From),
 		challengemanager.WithName(name),
-		challengemanager.WithAPIEnabled("localhost:3000", "/tmp/boldsqlite.db"),
 	)
 	honestManager := setupChallengeManager(
 		t, ctx, bk.Client(), rollupAddr, honestStateManager, txOpts, name, honestOpts...,
@@ -320,6 +319,4 @@ func runEndToEndTest(t *testing.T, cfg *e2eConfig) {
 		})
 	}
 	require.NoError(t, g.Wait())
-	ch := make(chan struct{})
-	<-ch
 }

--- a/testing/endtoend/e2e_test.go
+++ b/testing/endtoend/e2e_test.go
@@ -267,6 +267,7 @@ func runEndToEndTest(t *testing.T, cfg *e2eConfig) {
 		baseChallengeManagerOpts,
 		challengemanager.WithAddress(txOpts.From),
 		challengemanager.WithName(name),
+		challengemanager.WithAPIEnabled("localhost:3000", "/tmp/boldsqlite.db"),
 	)
 	honestManager := setupChallengeManager(
 		t, ctx, bk.Client(), rollupAddr, honestStateManager, txOpts, name, honestOpts...,

--- a/testing/endtoend/e2e_test.go
+++ b/testing/endtoend/e2e_test.go
@@ -320,4 +320,6 @@ func runEndToEndTest(t *testing.T, cfg *e2eConfig) {
 		})
 	}
 	require.NoError(t, g.Wait())
+	ch := make(chan struct{})
+	<-ch
 }


### PR DESCRIPTION
This PR shows a tracked edge's FSM in the API results when querying for it. This is helpful for us to understand if an edge is stuck in a certain state and with a certain error due to a bug, and allows us to diagnose the problems faster. It is important in situations when we don't know why an edge is not getting bisected and the actual error message