### PR TITLE
Improve Assertion Confirmation Conditions

### DIFF
--- a/assertions/scanner.go
+++ b/assertions/scanner.go
@@ -631,6 +631,14 @@ func (m *Manager) confirmAssertion(
 	if status == protocol.AssertionConfirmed {
 		return true, nil
 	}
+	latestConfirmed, err := m.chain.LatestConfirmed(ctx)
+	if err != nil {
+		return false, fmt.Errorf("could not get latest confirmed assertion: %v", err)
+	}
+	// The parent assertion must be the latest confirmed.
+	if creationInfo.ParentAssertionHash != latestConfirmed.Id().Hash {
+		return false, nil
+	}
 	creationBlock := creationInfo.CreationBlock
 	confirmPeriodBlocks := creationInfo.ConfirmPeriodBlocks
 	confirmableByTime := blockNumber >= creationBlock+confirmPeriodBlocks

--- a/assertions/scanner.go
+++ b/assertions/scanner.go
@@ -39,7 +39,6 @@ var (
 	evilAssertionCounter                  = metrics.NewRegisteredCounter("arb/validator/scanner/evil_assertion", nil)
 	challengeSubmittedCounter             = metrics.NewRegisteredCounter("arb/validator/scanner/challenge_submitted", nil)
 	assertionConfirmedCounter             = metrics.NewRegisteredCounter("arb/validator/scanner/assertion_confirmed", nil)
-	assertionConfirmedByTimeCounter       = metrics.NewRegisteredCounter("arb/validator/scanner/assertion_confirmed_time", nil)
 	errorConfirmingAssertionByTimeCounter = metrics.NewRegisteredCounter("arb/validator/scanner/error_confirming_assertion_by_time", nil)
 )
 

--- a/assertions/scanner.go
+++ b/assertions/scanner.go
@@ -568,6 +568,26 @@ func (m *Manager) keepTryingAssertionConfirmation(ctx context.Context, assertion
 	if m.challengeReader.Mode() < types.ResolveMode {
 		return
 	}
+	creationInfo, err := m.chain.ReadAssertionCreationInfo(ctx, assertionHash)
+	if err != nil {
+		log.Error("Could not get assertion creation info", log.Ctx{"error": err})
+		return
+	}
+	prevCreationInfo, err := m.chain.ReadAssertionCreationInfo(ctx, protocol.AssertionHash{Hash: creationInfo.ParentAssertionHash})
+	if err != nil {
+		log.Error("Could not get prev assertion creation info", log.Ctx{"error": err})
+		return
+	}
+	latestHeader, err := m.chain.Backend().HeaderByNumber(ctx, nil)
+	if err != nil {
+		srvlog.Error("Could not get latest header", log.Ctx{"err": err})
+		return
+	}
+	if !latestHeader.Number.IsUint64() {
+		srvlog.Error("Latest block number is not a uint64", log.Ctx{"number": latestHeader.Number.String()})
+		return
+	}
+	blockNumber := latestHeader.Number.Uint64()
 	for {
 		ticker := time.NewTicker(m.confirmationAttemptInterval)
 		defer ticker.Stop()
@@ -575,62 +595,49 @@ func (m *Manager) keepTryingAssertionConfirmation(ctx context.Context, assertion
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			// Challenged assertions should not be confirmed by time.
-			if m.challengeReader.IsChallengedAssertion(assertionHash) {
+			// Assertions that are specified as the claim id in a challenge
+			// cannot be confirmed by time, so we exit early.
+			if m.challengeReader.IsClaimedByChallenge(assertionHash) {
 				return
 			}
-			if m.assertionConfirmed(ctx, assertionHash) {
+			confirmed, err := m.confirmAssertion(ctx, creationInfo, prevCreationInfo, blockNumber)
+			if err != nil {
+				srvlog.Error("Could not confirm assertion", log.Ctx{"err": err, "assertionHash": assertionHash.Hash})
+				errorConfirmingAssertionByTimeCounter.Inc(1)
+				continue
+			}
+			if confirmed {
+				assertionConfirmedCounter.Inc(1)
+				srvlog.Info("Confirmed assertion", log.Ctx{"assertionHash": creationInfo.AssertionHash})
 				return
 			}
 		}
 	}
 }
 
-func (m *Manager) assertionConfirmed(ctx context.Context, assertionHash protocol.AssertionHash) bool {
-	// Challenged assertions should not be confirmed by time.
-	if m.challengeReader.IsChallengedAssertion(assertionHash) {
-		return false
-	}
-	status, err := m.chain.AssertionStatus(ctx, assertionHash)
+func (m *Manager) confirmAssertion(
+	ctx context.Context,
+	creationInfo *protocol.AssertionCreatedInfo,
+	prevCreationInfo *protocol.AssertionCreatedInfo,
+	blockNumber uint64,
+) (bool, error) {
+	status, err := m.chain.AssertionStatus(ctx, protocol.AssertionHash{Hash: creationInfo.AssertionHash})
 	if err != nil {
-		srvlog.Error("Could not get assertion by hash", log.Ctx{"err": err, "assertionHash": assertionHash.Hash})
-		return false
+		return false, fmt.Errorf("could not get assertion by hash: %#x: %w", creationInfo.AssertionHash, err)
 	}
 	if status == protocol.NoAssertion {
-		srvlog.Error("No assertion found by hash", log.Ctx{"err": err, "assertionHash": assertionHash.Hash})
-		return false
+		return false, fmt.Errorf("no assertion found by hash: %#x", creationInfo.AssertionHash)
 	}
 	if status == protocol.AssertionConfirmed {
-		assertionConfirmedCounter.Inc(1)
-		srvlog.Info("Assertion confirmed", log.Ctx{"assertionHash": assertionHash.Hash})
-		return true
-	}
-	creationInfo, err := m.chain.ReadAssertionCreationInfo(ctx, assertionHash)
-	if err != nil {
-		srvlog.Error("Could not get assertion creation info by hash", log.Ctx{"err": err, "assertionHash": assertionHash.Hash})
-		return false
-	}
-	prevCreationInfo, err := m.chain.ReadAssertionCreationInfo(ctx, protocol.AssertionHash{Hash: creationInfo.ParentAssertionHash})
-	if err != nil {
-		srvlog.Error("Could not get assertion creation info by hash", log.Ctx{"err": err, "assertionHash": creationInfo.ParentAssertionHash})
-		return false
-	}
-	latestHeader, err := m.chain.Backend().HeaderByNumber(ctx, nil)
-	if err != nil {
-		srvlog.Error("Could not get latest header", log.Ctx{"err": err})
-		return false
-	}
-	if !latestHeader.Number.IsUint64() {
-		srvlog.Error("Latest block number is not a uint64", log.Ctx{"number": latestHeader.Number.String()})
-		return false
+		return true, nil
 	}
 	creationBlock := creationInfo.CreationBlock
-	confirmPeriodBlocks := prevCreationInfo.ConfirmPeriodBlocks
-	currentBlock := latestHeader.Number.Uint64()
+	confirmPeriodBlocks := creationInfo.ConfirmPeriodBlocks
+	confirmableByTime := blockNumber >= creationBlock+confirmPeriodBlocks
 
-	// If the assertion is not yet confirmable, we can simply wait until we are confirmable by time.
-	if currentBlock < creationBlock+confirmPeriodBlocks {
-		blocksLeftForConfirmation := (creationBlock + confirmPeriodBlocks) - currentBlock
+	// If the assertion is not yet confirmable, we can simply wait.
+	if !confirmableByTime {
+		blocksLeftForConfirmation := (creationBlock + confirmPeriodBlocks) - blockNumber
 		timeToWait := m.averageTimeForBlockCreation * time.Duration(blocksLeftForConfirmation)
 		srvlog.Info(
 			fmt.Sprintf(
@@ -642,23 +649,15 @@ func (m *Manager) assertionConfirmed(ctx context.Context, assertionHash protocol
 		)
 		<-time.After(timeToWait)
 	}
-	// Challenged assertions should not be confirmed by time.
-	if m.challengeReader.IsChallengedAssertion(assertionHash) {
-		return false
-	}
 
-	err = m.chain.ConfirmAssertionByTime(ctx, assertionHash)
+	err = m.chain.ConfirmAssertionByTime(ctx, protocol.AssertionHash{Hash: creationInfo.AssertionHash})
 	if err != nil {
 		if strings.Contains(err.Error(), protocol.BeforeDeadlineAssertionConfirmationError) {
-			return false
+			return false, nil
 		}
-		srvlog.Error("Could not confirm assertion by time", log.Ctx{"blockNumber": latestHeader.Number.String(), "error": err, "hash": assertionHash.Hash})
-		errorConfirmingAssertionByTimeCounter.Inc(1)
-		return false
+		return false, err
 	}
-	assertionConfirmedByTimeCounter.Inc(1)
-	srvlog.Info("Assertion confirmed", log.Ctx{"assertionHash": assertionHash.Hash})
-	return true
+	return true, nil
 }
 
 // Returns true if the manager can respond to an assertion with a challenge.

--- a/challenge-manager/manager.go
+++ b/challenge-manager/manager.go
@@ -71,7 +71,7 @@ type Manager struct {
 	mode                        types.Mode
 	maxDelaySeconds             int
 
-	challengedAssertions *threadsafe.Set[protocol.AssertionHash]
+	claimedAssertionsInChallenge *threadsafe.Set[protocol.AssertionHash]
 	// API
 	apiAddr   string
 	apiDBPath string
@@ -151,20 +151,20 @@ func New(
 ) (*Manager, error) {
 
 	m := &Manager{
-		backend:                     backend,
-		chain:                       chain,
-		stateManager:                stateManager,
-		address:                     common.Address{},
-		timeRef:                     utilTime.NewRealTimeReference(),
-		rollupAddr:                  rollupAddr,
-		chainWatcherInterval:        time.Millisecond * 500,
-		trackedEdgeIds:              threadsafe.NewSet[protocol.EdgeId](threadsafe.SetWithMetric[protocol.EdgeId]("trackedEdgeIds")),
-		batchIndexForAssertionCache: threadsafe.NewMap[protocol.AssertionHash, edgetracker.AssociatedAssertionMetadata](threadsafe.MapWithMetric[protocol.AssertionHash, edgetracker.AssociatedAssertionMetadata]("batchIndexForAssertionCache")),
-		assertionPostingInterval:    time.Hour,
-		assertionScanningInterval:   time.Minute,
-		assertionConfirmingInterval: time.Second * 10,
-		averageTimeForBlockCreation: time.Second * 12,
-		challengedAssertions:        threadsafe.NewSet[protocol.AssertionHash](threadsafe.SetWithMetric[protocol.AssertionHash]("challengedAssertions")),
+		backend:                      backend,
+		chain:                        chain,
+		stateManager:                 stateManager,
+		address:                      common.Address{},
+		timeRef:                      utilTime.NewRealTimeReference(),
+		rollupAddr:                   rollupAddr,
+		chainWatcherInterval:         time.Millisecond * 500,
+		trackedEdgeIds:               threadsafe.NewSet[protocol.EdgeId](threadsafe.SetWithMetric[protocol.EdgeId]("trackedEdgeIds")),
+		batchIndexForAssertionCache:  threadsafe.NewMap[protocol.AssertionHash, edgetracker.AssociatedAssertionMetadata](threadsafe.MapWithMetric[protocol.AssertionHash, edgetracker.AssociatedAssertionMetadata]("batchIndexForAssertionCache")),
+		assertionPostingInterval:     time.Hour,
+		assertionScanningInterval:    time.Minute,
+		assertionConfirmingInterval:  time.Second * 10,
+		averageTimeForBlockCreation:  time.Second * 12,
+		claimedAssertionsInChallenge: threadsafe.NewSet[protocol.AssertionHash](threadsafe.SetWithMetric[protocol.AssertionHash]("claimedAssertionsInChallenge")),
 	}
 	for _, o := range opts {
 		o(m)
@@ -271,8 +271,8 @@ func (m *Manager) Mode() types.Mode {
 }
 
 // IsChallengedAssertion checks if an assertion with a given hash has a challenge.
-func (m *Manager) IsChallengedAssertion(assertionHash protocol.AssertionHash) bool {
-	return m.challengedAssertions.Has(assertionHash)
+func (m *Manager) IsClaimedByChallenge(assertionHash protocol.AssertionHash) bool {
+	return m.claimedAssertionsInChallenge.Has(assertionHash)
 }
 
 // MaxDelaySeconds returns the maximum number of seconds that the challenge manager will wait open a challenge.

--- a/challenge-manager/manager.go
+++ b/challenge-manager/manager.go
@@ -159,7 +159,7 @@ func New(
 		timeRef:                      utilTime.NewRealTimeReference(),
 		rollupAddr:                   rollupAddr,
 		chainWatcherInterval:         time.Millisecond * 500,
-		trackedEdgeIds:              threadsafe.NewMap[protocol.EdgeId, *edgetracker.Tracker](threadsafe.MapWithMetric[protocol.EdgeId, *edgetracker.Tracker]("trackedEdgeIds")),
+		trackedEdgeIds:               threadsafe.NewMap[protocol.EdgeId, *edgetracker.Tracker](threadsafe.MapWithMetric[protocol.EdgeId, *edgetracker.Tracker]("trackedEdgeIds")),
 		batchIndexForAssertionCache:  threadsafe.NewMap[protocol.AssertionHash, edgetracker.AssociatedAssertionMetadata](threadsafe.MapWithMetric[protocol.AssertionHash, edgetracker.AssociatedAssertionMetadata]("batchIndexForAssertionCache")),
 		assertionPostingInterval:     time.Hour,
 		assertionScanningInterval:    time.Minute,

--- a/challenge-manager/types/interfaces.go
+++ b/challenge-manager/types/interfaces.go
@@ -24,5 +24,5 @@ type ChallengeCreator interface {
 type ChallengeReader interface {
 	Mode() Mode
 	MaxDelaySeconds() int
-	IsChallengedAssertion(assertionHash protocol.AssertionHash) bool
+	IsClaimedByChallenge(assertionHash protocol.AssertionHash) bool
 }


### PR DESCRIPTION
This PR improves the assertion confirmation conditions, as they were quite messy and were missing several important details.

### Background

Assertions are confirmed by the assertion manager component of the BOLD code. It will try to confirm assertions by time using a ticker until the confirmation occurs. However, there were some problems:

- We were missing a check that the previous assertion must be the latest confirmed
- We were fetching onchain, immutable data on each tick of the goroutine
- It is possible that the parent assertion of a challenge is confirmed by time, but our current code was not considering that
- We should exit if the assertion is claimed in a challenge, as in that case it should be confirmed by winning edge id