### PR TITLE
Prevent Assertion Not Yet in DB From Blocking Call to InsertEdge

### DIFF
--- a/api/db/db.go
+++ b/api/db/db.go
@@ -677,7 +677,6 @@ func (d *SqliteDatabase) InsertEdge(edge *api.JsonEdge) error {
 		}
 		return nil
 	}
-	// Check if the assertion exists
 	var assertionExists int
 	err = tx.Get(&assertionExists, "SELECT COUNT(*) FROM Assertions WHERE Hash = ?", edge.AssertionHash)
 	if err != nil {
@@ -686,30 +685,27 @@ func (d *SqliteDatabase) InsertEdge(edge *api.JsonEdge) error {
 		}
 		return err
 	}
-	if assertionExists == 0 {
-		if err2 := tx.Rollback(); err2 != nil {
-			return err2
-		}
-		return errors.Wrapf(ErrNoAssertionForEdge, "edge_id=%#x, assertion_hash=%#x", edge.Id, edge.AssertionHash)
-	}
-	// Check if a challenge exists for the assertion
-	var challengeExists int
-	err = tx.Get(&challengeExists, "SELECT COUNT(*) FROM Challenges WHERE Hash = ?", edge.AssertionHash)
-	if err != nil {
-		if err2 := tx.Rollback(); err2 != nil {
-			return err2
-		}
-		return err
-	}
-	// If the assertion exists but not the challenge, create the challenge
-	if challengeExists == 0 {
-		insertChallengeQuery := `INSERT INTO Challenges (Hash) VALUES (?)`
-		_, err = tx.Exec(insertChallengeQuery, edge.AssertionHash)
+	// Check if an associated assertion for the edge exists.
+	if assertionExists != 0 {
+		// Check if a challenge exists for the assertion.
+		var challengeExists int
+		err = tx.Get(&challengeExists, "SELECT COUNT(*) FROM Challenges WHERE Hash = ?", edge.AssertionHash)
 		if err != nil {
 			if err2 := tx.Rollback(); err2 != nil {
 				return err2
 			}
 			return err
+		}
+		// If the assertion exists but not the challenge, create the challenge
+		if challengeExists == 0 {
+			insertChallengeQuery := `INSERT INTO Challenges (Hash) VALUES (?)`
+			_, err = tx.Exec(insertChallengeQuery, edge.AssertionHash)
+			if err != nil {
+				if err2 := tx.Rollback(); err2 != nil {
+					return err2
+				}
+				return err
+			}
 		}
 	}
 	insertEdgeQuery := `INSERT INTO Edges (

--- a/api/db/db.go
+++ b/api/db/db.go
@@ -14,11 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/jmoiron/sqlx"
 	_ "github.com/mattn/go-sqlite3"
-	"github.com/pkg/errors"
-)
-
-var (
-	ErrNoAssertionForEdge = errors.New("no matching assertion found for edge")
 )
 
 type Database interface {

--- a/api/db/db_test.go
+++ b/api/db/db_test.go
@@ -129,8 +129,6 @@ func TestSqliteDatabase_Assertions(t *testing.T) {
 
 	// Inserting edges that don't have an associated assertion should fail.
 	db := &SqliteDatabase{sqlDB: sqlDB}
-	err = db.InsertEdges([]*api.JsonEdge{baseEdge()})
-	require.ErrorIs(t, err, ErrNoAssertionForEdge)
 
 	numAssertions := 10
 	assertionsToCreate := make([]*api.JsonAssertion, numAssertions)
@@ -297,8 +295,6 @@ func TestSqliteDatabase_Edges(t *testing.T) {
 
 	// Inserting edges that don't have an associated assertion should fail.
 	db := &SqliteDatabase{sqlDB: sqlDB}
-	err = db.InsertEdges([]*api.JsonEdge{baseEdge()})
-	require.ErrorIs(t, err, ErrNoAssertionForEdge)
 
 	numAssertions := 10
 	assertionsToCreate := make([]*api.JsonAssertion, numAssertions)

--- a/assertions/scanner.go
+++ b/assertions/scanner.go
@@ -276,6 +276,10 @@ func (m *Manager) ProcessAssertionCreationEvent(
 	ctx context.Context,
 	assertionHash protocol.AssertionHash,
 ) error {
+	// Save the assertion creation event to the DB if possible.
+	if err := m.saveAssertionToDB(ctx, assertionHash); err != nil {
+		return err
+	}
 	// Ignore assertions we have submitted ourselves.
 	if m.submittedAssertions.Has(assertionHash.Hash) {
 		return nil
@@ -286,10 +290,6 @@ func (m *Manager) ProcessAssertionCreationEvent(
 	creationInfo, err := m.chain.ReadAssertionCreationInfo(ctx, assertionHash)
 	if err != nil {
 		return errors.Wrapf(err, "could not read assertion creation info for %#x", assertionHash.Hash)
-	}
-	// Save the assertion creation event to the DB if possible.
-	if err2 := m.saveAssertionToDB(ctx, assertionHash); err2 != nil {
-		return err2
 	}
 	if creationInfo.ParentAssertionHash == (common.Hash{}) {
 		return nil // Skip processing genesis, as it has a parent assertion hash of 0x0.


### PR DESCRIPTION
This check was preventing edges from being saved to the DB, which would cause a lot of problems for the validator