### PR TITLE
Skip Submitting Rival, Honest Assertions if Observing an Assertion from an Evil Fork

### DIFF
--- a/api/db/BUILD.bazel
+++ b/api/db/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "@com_github_ethereum_go_ethereum//common",
         "@com_github_jmoiron_sqlx//:sqlx",
         "@com_github_mattn_go_sqlite3//:go-sqlite3",
-        "@com_github_pkg_errors//:errors",
     ],
 )
 

--- a/assertions/BUILD.bazel
+++ b/assertions/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//util",
         "@com_github_ethereum_go_ethereum//accounts/abi/bind",
         "@com_github_ethereum_go_ethereum//common",
+        "@com_github_ethereum_go_ethereum//core/types",
         "@com_github_ethereum_go_ethereum//crypto",
         "@com_github_ethereum_go_ethereum//log",
         "@com_github_ethereum_go_ethereum//metrics",


### PR DESCRIPTION
If we have a situation like this:
```
  /--B--C--D(evil)
A
```
where an honest Alice has not yet participated, if we she sees `D`, she will backtrack and post an honest rival to `B`. However, if the evil chain keeps growing, she will attempt that same routine again and try to submit an already existing rival to `B` and challenge again, wasting resources and time. We add a check that skips this duplicate submission even if we see a growing, evil assertion chain.