### PR TITLE
Calculate and store timers offline

### DIFF
--- a/chain-abstraction/interfaces.go
+++ b/chain-abstraction/interfaces.go
@@ -247,16 +247,25 @@ type SpecChallengeManager interface {
 	// The inherited timer from the edge's children. Needs to be refreshed
 	// onchain over time.
 	InheritedTimer(ctx context.Context, edgeId EdgeId) (uint64, error)
-	UpdateInheritedTimerByClaim(
+	UpdateInheritedTimerByClaimOffChain(
 		ctx context.Context,
 		claimingEdgeId EdgeId,
 		timeUnrivaled uint64,
 		claimId ClaimId,
 	) error
-	UpdateInheritedTimerByChildren(
+	UpdateInheritedTimerByClaim(
+		ctx context.Context,
+		claimingEdgeId EdgeId,
+		claimId ClaimId,
+	) error
+	UpdateInheritedTimerByChildrenOffChain(
 		ctx context.Context,
 		edgeId EdgeId,
 		timeUnrivaledTotal uint64,
+	) error
+	UpdateInheritedTimerByChildren(
+		ctx context.Context,
+		edgeId EdgeId,
 	) error
 	// Calculates an edge id for an edge.
 	CalculateEdgeId(

--- a/chain-abstraction/interfaces.go
+++ b/chain-abstraction/interfaces.go
@@ -250,11 +250,13 @@ type SpecChallengeManager interface {
 	UpdateInheritedTimerByClaim(
 		ctx context.Context,
 		claimingEdgeId EdgeId,
+		timeUnrivaled uint64,
 		claimId ClaimId,
 	) error
 	UpdateInheritedTimerByChildren(
 		ctx context.Context,
 		edgeId EdgeId,
+		timeUnrivaledTotal uint64,
 	) error
 	// Calculates an edge id for an edge.
 	CalculateEdgeId(

--- a/chain-abstraction/sol-implementation/assertion_chain.go
+++ b/chain-abstraction/sol-implementation/assertion_chain.go
@@ -12,7 +12,6 @@ import (
 	"math/big"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	protocol "github.com/OffchainLabs/bold/chain-abstraction"
@@ -107,7 +106,6 @@ func (d *DataPosterTransactor) SendTransaction(ctx context.Context, tx *types.Tr
 // AssertionChain is a wrapper around solgen bindings
 // that implements the protocol interface.
 type AssertionChain struct {
-	transactionLock                          sync.Mutex
 	backend                                  protocol.ChainBackend
 	rollup                                   *rollupgen.RollupCore
 	userLogic                                *rollupgen.RollupUserLogic

--- a/chain-abstraction/sol-implementation/edge_challenge_manager.go
+++ b/chain-abstraction/sol-implementation/edge_challenge_manager.go
@@ -407,7 +407,7 @@ func NewSpecChallengeManager(
 		filterer:                        &managerBinding.EdgeChallengeManagerFilterer,
 		numBigStepLevel:                 numBigStepLevel,
 		challengePeriodBlocks:           challengePeriodBlocks,
-		totalTimeUnrivaledCacheByEdgeId: threadsafe.NewMap[protocol.EdgeId, uint64](),
+		totalTimeUnrivaledCacheByEdgeId: threadsafe.NewMap[protocol.EdgeId, uint64](threadsafe.MapWithMetric[protocol.EdgeId, uint64]("totalTimeUnrivaledCacheByEdgeId")),
 	}, nil
 }
 

--- a/chain-abstraction/sol-implementation/edge_challenge_manager.go
+++ b/chain-abstraction/sol-implementation/edge_challenge_manager.go
@@ -595,7 +595,7 @@ func (cm *specChallengeManager) CalculateEdgeId(
 	return protocol.EdgeId{Hash: id}, err
 }
 
-func (cm *specChallengeManager) UpdateInheritedTimerByChildren(
+func (cm *specChallengeManager) UpdateInheritedTimerByChildrenOffChain(
 	ctx context.Context,
 	edgeId protocol.EdgeId,
 	timeUnrivaledTotal uint64,
@@ -611,7 +611,54 @@ func (cm *specChallengeManager) UpdateInheritedTimerByChildren(
 	return nil
 }
 
+func (cm *specChallengeManager) UpdateInheritedTimerByChildren(
+	ctx context.Context,
+	edgeId protocol.EdgeId,
+) error {
+	if _, err := cm.assertionChain.transact(
+		ctx,
+		cm.assertionChain.backend,
+		func(opts *bind.TransactOpts) (*types.Transaction, error) {
+			return cm.writer.UpdateTimerCacheByChildren(
+				opts,
+				edgeId.Hash,
+			)
+		}); err != nil {
+		return errors.Wrapf(
+			err,
+			"could not update inherited timer for edge by children %#x",
+			edgeId,
+		)
+	}
+	return nil
+}
+
 func (cm *specChallengeManager) UpdateInheritedTimerByClaim(
+	ctx context.Context,
+	claimingEdgeId protocol.EdgeId,
+	claimId protocol.ClaimId,
+) error {
+	if _, err := cm.assertionChain.transact(
+		ctx,
+		cm.assertionChain.backend,
+		func(opts *bind.TransactOpts) (*types.Transaction, error) {
+			return cm.writer.UpdateTimerCacheByClaim(
+				opts,
+				common.Hash(claimId),
+				claimingEdgeId.Hash,
+			)
+		}); err != nil {
+		return errors.Wrapf(
+			err,
+			"could not update inherited timer for edge by claim: claim id %#x, claiming edge id %#x",
+			common.Hash(claimId),
+			claimingEdgeId.Hash,
+		)
+	}
+	return nil
+}
+
+func (cm *specChallengeManager) UpdateInheritedTimerByClaimOffChain(
 	ctx context.Context,
 	claimingEdgeId protocol.EdgeId,
 	timeUnrivaled uint64,

--- a/challenge-manager/chain-watcher/watcher.go
+++ b/challenge-manager/chain-watcher/watcher.go
@@ -37,10 +37,8 @@ import (
 var (
 	srvlog                                  = log.New("service", "chain-watcher")
 	edgeAddedCounter                        = metrics.NewRegisteredCounter("arb/validator/watcher/edge_added", nil)
-	edgeConfirmedByChildrenCounter          = metrics.NewRegisteredCounter("arb/validator/watcher/confirmed_by_children", nil)
 	edgeConfirmedByTimeCounter              = metrics.NewRegisteredCounter("arb/validator/watcher/confirmed_by_time", nil)
 	edgeConfirmedByOSPCounter               = metrics.NewRegisteredCounter("arb/validator/watcher/confirmed_by_osp", nil)
-	edgeConfirmedByClaimCounter             = metrics.NewRegisteredCounter("arb/validator/watcher/confirmed_by_claim", nil)
 	errorConfirmingAssertionByWinnerCounter = metrics.NewRegisteredCounter("arb/validator/watcher/error_confirming_assertion_by_winner", nil)
 	assertionConfirmedCounter               = metrics.GetOrRegisterCounter("arb/validator/scanner/assertion_confirmed", nil)
 )

--- a/challenge-manager/challenge-tree/tree.go
+++ b/challenge-manager/challenge-tree/tree.go
@@ -161,7 +161,7 @@ func (ht *RoyalChallengeTree) UpdateInheritedTimer(
 	// if they are able to.
 	if edge.ClaimId().IsSome() && edge.GetChallengeLevel() != protocol.NewBlockChallengeLevel() {
 		claimedEdgeId := edge.ClaimId().Unwrap()
-		if err = chalManager.UpdateInheritedTimerByClaim(ctx, edgeId, timeUnrivaled, claimedEdgeId); err != nil {
+		if err = chalManager.UpdateInheritedTimerByClaimOffChain(ctx, edgeId, timeUnrivaled, claimedEdgeId); err != nil {
 			srvlog.Info("Could not update inherited timer by claim", log.Ctx{"error": err})
 		}
 	}
@@ -171,7 +171,7 @@ func (ht *RoyalChallengeTree) UpdateInheritedTimer(
 		return 0, err
 	}
 	if inheritedTimer > onchainTimer {
-		if err = chalManager.UpdateInheritedTimerByChildren(ctx, edgeId, inheritedTimer); err != nil {
+		if err = chalManager.UpdateInheritedTimerByChildrenOffChain(ctx, edgeId, inheritedTimer); err != nil {
 			srvlog.Info("Could not update inherited timer by children", log.Ctx{"error": err})
 		}
 	}

--- a/challenge-manager/challenge-tree/tree.go
+++ b/challenge-manager/challenge-tree/tree.go
@@ -161,11 +161,9 @@ func (ht *RoyalChallengeTree) UpdateInheritedTimer(
 	// if they are able to.
 	if edge.ClaimId().IsSome() && edge.GetChallengeLevel() != protocol.NewBlockChallengeLevel() {
 		claimedEdgeId := edge.ClaimId().Unwrap()
-		go func() {
-			if err = chalManager.UpdateInheritedTimerByClaim(ctx, edgeId, claimedEdgeId); err != nil {
-				srvlog.Info("Could not update inherited timer by claim", log.Ctx{"error": err})
-			}
-		}()
+		if err = chalManager.UpdateInheritedTimerByClaim(ctx, edgeId, timeUnrivaled, claimedEdgeId); err != nil {
+			srvlog.Info("Could not update inherited timer by claim", log.Ctx{"error": err})
+		}
 	}
 
 	onchainTimer, err := chalManager.InheritedTimer(ctx, edgeId)
@@ -173,11 +171,9 @@ func (ht *RoyalChallengeTree) UpdateInheritedTimer(
 		return 0, err
 	}
 	if inheritedTimer > onchainTimer {
-		go func() {
-			if err = chalManager.UpdateInheritedTimerByChildren(ctx, edgeId); err != nil {
-				srvlog.Info("Could not update inherited timer by children", log.Ctx{"error": err})
-			}
-		}()
+		if err = chalManager.UpdateInheritedTimerByChildren(ctx, edgeId, inheritedTimer); err != nil {
+			srvlog.Info("Could not update inherited timer by children", log.Ctx{"error": err})
+		}
 	}
 	// Otherwise, the edge does not yet have children.
 	return inheritedTimer, nil

--- a/challenge-manager/challenge-tree/tree_test.go
+++ b/challenge-manager/challenge-tree/tree_test.go
@@ -324,7 +324,7 @@ func TestUpdateInheritedTimer(t *testing.T) {
 			assertionHash: protocol.AssertionHash{},
 			mockManager:   &mocks.MockSpecChallengeManager{},
 		}
-		m.mockManager.On("UpdateInheritedTimerByChildren", ctx, edge.Id()).Return(nil)
+		m.mockManager.On("UpdateInheritedTimerByChildrenOffChain", ctx, edge.Id(), uint64(9)).Return(nil)
 		m.mockManager.On("InheritedTimer", ctx, edge.Id()).Return(uint64(0), nil)
 		ht.metadataReader = m
 		ht.edges.Put(edge.Id(), edge)
@@ -349,7 +349,7 @@ func TestUpdateInheritedTimer(t *testing.T) {
 		m.mockManager.On("InheritedTimer", ctx, edge.Id()).Return(uint64(0), nil)
 		m.mockManager.On("InheritedTimer", ctx, lowerChild.Id()).Return(uint64(5), nil)
 		m.mockManager.On("InheritedTimer", ctx, upperChild.Id()).Return(uint64(2), nil)
-		m.mockManager.On("UpdateInheritedTimerByChildren", ctx, edge.Id()).Return(nil)
+		m.mockManager.On("UpdateInheritedTimerByChildrenOffChain", ctx, edge.Id(), uint64(11)).Return(nil)
 		ht.metadataReader = m
 		timer, err := ht.UpdateInheritedTimer(ctx, edge.Id(), 10)
 		require.NoError(t, err)
@@ -372,7 +372,7 @@ func TestUpdateInheritedTimer(t *testing.T) {
 		m.mockManager.On("InheritedTimer", ctx, edge.Id()).Return(uint64(0), nil)
 		m.mockManager.On("InheritedTimer", ctx, lowerChild.Id()).Return(uint64(math.MaxUint64), nil)
 		m.mockManager.On("InheritedTimer", ctx, upperChild.Id()).Return(uint64(math.MaxUint64), nil)
-		m.mockManager.On("UpdateInheritedTimerByChildren", ctx, edge.Id()).Return(nil)
+		m.mockManager.On("UpdateInheritedTimerByChildrenOffChain", ctx, edge.Id(), uint64(math.MaxUint64)).Return(nil)
 		ht.metadataReader = m
 		timer, err := ht.UpdateInheritedTimer(ctx, edge.Id(), 10)
 		require.NoError(t, err)
@@ -391,8 +391,8 @@ func TestUpdateInheritedTimer(t *testing.T) {
 		ht.edges.Put(claimedEdge.Id(), claimedEdge)
 		// Expect this function is called.
 		m.mockManager.On("InheritedTimer", ctx, edge.Id()).Return(uint64(0), nil)
-		m.mockManager.On("UpdateInheritedTimerByClaim", ctx, edge.Id(), edge.ClaimId().Unwrap()).Return(nil)
-		m.mockManager.On("UpdateInheritedTimerByChildren", ctx, edge.Id()).Return(nil)
+		m.mockManager.On("UpdateInheritedTimerByClaimOffChain", ctx, edge.Id(), uint64(8), edge.ClaimId().Unwrap()).Return(nil)
+		m.mockManager.On("UpdateInheritedTimerByChildrenOffChain", ctx, edge.Id(), uint64(8)).Return(nil)
 		ht.metadataReader = m
 		timer, err := ht.UpdateInheritedTimer(ctx, edge.Id(), 10)
 		require.NoError(t, err)

--- a/testing/mocks/mocks.go
+++ b/testing/mocks/mocks.go
@@ -175,16 +175,18 @@ func (m *MockSpecChallengeManager) InheritedTimer(ctx context.Context, edgeId pr
 	args := m.Called(ctx, edgeId)
 	return args.Get(0).(uint64), args.Error(1)
 }
-func (m *MockSpecChallengeManager) UpdateInheritedTimerByChildren(ctx context.Context, edgeId protocol.EdgeId) error {
-	args := m.Called(ctx, edgeId)
+func (m *MockSpecChallengeManager) UpdateInheritedTimerByChildren(ctx context.Context, edgeId protocol.EdgeId, timeUnrivaledTotal uint64, ) error {
+	args := m.Called(ctx, edgeId, timeUnrivaledTotal)
 	return args.Error(0)
 }
 func (m *MockSpecChallengeManager) UpdateInheritedTimerByClaim(
 	ctx context.Context,
 	claimingEdgeId protocol.EdgeId,
+	timeUnrivaled uint64,
 	claimId protocol.ClaimId,
+
 ) error {
-	args := m.Called(ctx, claimingEdgeId, claimId)
+	args := m.Called(ctx, claimingEdgeId, timeUnrivaled, claimId)
 	return args.Error(0)
 }
 

--- a/testing/mocks/mocks.go
+++ b/testing/mocks/mocks.go
@@ -175,11 +175,27 @@ func (m *MockSpecChallengeManager) InheritedTimer(ctx context.Context, edgeId pr
 	args := m.Called(ctx, edgeId)
 	return args.Get(0).(uint64), args.Error(1)
 }
-func (m *MockSpecChallengeManager) UpdateInheritedTimerByChildren(ctx context.Context, edgeId protocol.EdgeId, timeUnrivaledTotal uint64, ) error {
+func (m *MockSpecChallengeManager) UpdateInheritedTimerByChildrenOffChain(ctx context.Context, edgeId protocol.EdgeId, timeUnrivaledTotal uint64) error {
 	args := m.Called(ctx, edgeId, timeUnrivaledTotal)
 	return args.Error(0)
 }
+
+func (m *MockSpecChallengeManager) UpdateInheritedTimerByChildren(ctx context.Context, edgeId protocol.EdgeId) error {
+	args := m.Called(ctx, edgeId)
+	return args.Error(0)
+}
+
 func (m *MockSpecChallengeManager) UpdateInheritedTimerByClaim(
+	ctx context.Context,
+	claimingEdgeId protocol.EdgeId,
+	claimId protocol.ClaimId,
+
+) error {
+	args := m.Called(ctx, claimingEdgeId, claimId)
+	return args.Error(0)
+}
+
+func (m *MockSpecChallengeManager) UpdateInheritedTimerByClaimOffChain(
 	ctx context.Context,
 	claimingEdgeId protocol.EdgeId,
 	timeUnrivaled uint64,


### PR DESCRIPTION
Currently we make too many transaction to update edge timer.

To avoid this we need 2 things:

1. Do not rely on chain data for calculating the edge timer.
2. Update the timer on chain only when confirming the edge

This PR handle point 1 (Calculate and store timers offline, without onchain help).
Point 2 will be handled in a separate PR.