### PR TITLE
Error if Bridge Data Not Correct

### DIFF
--- a/assertions/poster.go
+++ b/assertions/poster.go
@@ -158,6 +158,16 @@ func (m *Manager) PostAssertionBasedOnParent(
 		newState,
 	)
 	if err != nil {
+		if errors.Is(err, l2stateprovider.ErrChainCatchingUp) {
+			chainCatchingUpCounter.Inc(1)
+			srvlog.Info(
+				"Has not yet observed assertion with batch count on safe head, will try posting next time", log.Ctx{
+					"batchCount":    batchCount,
+					"validatorName": m.validatorName,
+				},
+			)
+			return none, nil
+		}
 		return none, err
 	}
 	srvlog.Info("Submitted latest L2 state claim as an assertion to L1", log.Ctx{

--- a/chain-abstraction/sol-implementation/BUILD.bazel
+++ b/chain-abstraction/sol-implementation/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//containers",
         "//containers/option",
         "//containers/threadsafe",
+        "//layer2-state-provider",
         "//solgen/go/bridgegen",
         "//solgen/go/challengeV2gen",
         "//solgen/go/ospgen",


### PR DESCRIPTION
Checks if the number of sequencer messages in the inbox is < what we are trying to post as an assertion, and return ErrCatchingUp if so. This prevents errors when trying to post an assertion if we are using safe head