### PR TITLE
Add option to fast sync validator during challenge

### DIFF
--- a/challenge-manager/challenges.go
+++ b/challenge-manager/challenges.go
@@ -67,6 +67,8 @@ func (m *Manager) ChallengeAssertion(ctx context.Context, id protocol.AssertionH
 		m.watcher,
 		m,
 		edgeTrackerAssertionInfo,
+		m.validatorStartTime,
+		m.fastSyncDuration,
 		edgetracker.WithActInterval(m.edgeTrackerWakeInterval),
 		edgetracker.WithTimeReference(m.timeRef),
 		edgetracker.WithValidatorName(m.name),

--- a/challenge-manager/manager_test.go
+++ b/challenge-manager/manager_test.go
@@ -193,6 +193,8 @@ func setupEdgeTrackersForBisection(
 		honestWatcher,
 		honestValidator,
 		assertionInfo,
+		time.Now(),
+		time.Duration(0),
 		edgetracker.WithTimeReference(customTime.NewArtificialTimeReference()),
 		edgetracker.WithValidatorName(honestValidator.name),
 	)
@@ -209,6 +211,8 @@ func setupEdgeTrackersForBisection(
 		evilWatcher,
 		evilValidator,
 		assertionInfo,
+		time.Now(),
+		time.Duration(0),
 		edgetracker.WithTimeReference(customTime.NewArtificialTimeReference()),
 		edgetracker.WithValidatorName(evilValidator.name),
 	)


### PR DESCRIPTION
This is being done to avoid waiting for long periods to act if the validator has been restarted during a challenge.

Basically for a fixed set of duration from the start of the node, the validator will act in fast sync mode to allow fast calling of the act function.