### PR TITLE
update testnode addresses

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -219,6 +219,8 @@ jobs:
       - uses: OffchainLabs/actions/run-nitro-test-node@main
         with:
           no-simple: false
+          nitro-contracts-branch: "2e8eeb9f28104465de0557851aa7607b037cafcf"
+          token-bridge-branch: "v1.2.1"
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/contracts/scripts/files/localConfig.json
+++ b/contracts/scripts/files/localConfig.json
@@ -1,19 +1,19 @@
 {
   "contracts": {
-    "l1Timelock": "0x6900354cF23D12A2c3cc98F48F1a28f9e3Ca1029",
-    "bridge": "0x6900354cF23D12A2c3cc98F48F1a28f9e3Ca1029",
-    "inbox": "0xAc4C9Ac691E928C3D004773efc9CA4Ca76747a2e",
-    "outbox": "0xa5f95320288c773fe9e568a404c7A4305a75C70A",
-    "rollup": "0x23a0311dc615bae798666c73500bdca005eefbcf",
-    "sequencerInbox": "0xd7EEdf4eA5dE1868EB825c39fb0d2cbE2d0EFdC0",
-    "rollupEventInbox": "0x23f10f9725ab85ebe53e452d6e3e8b165a4d5eef",
-    "upgradeExecutor": "0xfb0a643101012625fa222ce07c75e3a53381f1a9"
+    "bridge": "0x5eCF728ffC5C5E802091875f96281B5aeECf6C49",
+    "inbox": "0x9f8c1c641336A371031499e3c362e40d58d0f254",
+    "outbox": "0x50143333b44Ea46255BEb67255C9Afd35551072F",
+    "rollup": "0x8553016d4F782A42882BD982CDaD9a3B3dfb36BC",
+    "sequencerInbox": "0x18d19C5d3E685f5be5b9C86E097f0E439285D216",
+    "rollupEventInbox": "0x0e73faf857e1ca53e700856fcf19f31f920a1e3c",
+    "upgradeExecutor": "0x513d9f96d4d0563debae8a0dc307ea0e46b10ed7",
+    "l1Timelock": "0x8553016d4F782A42882BD982CDaD9a3B3dfb36BC"
   },
   "proxyAdmins": {
-    "outbox": "0x05485096e90ea515807b233e26758705d93b3b7a",
-    "bridge": "0x05485096e90ea515807b233e26758705d93b3b7a",
-    "rei": "0x05485096e90ea515807b233e26758705d93b3b7a",
-    "seqInbox": "0x05485096e90ea515807b233e26758705d93b3b7a"
+    "outbox": "0x2a1f38c9097e7883570e0b02bfbe6869cc25d8a3",
+    "bridge": "0x2a1f38c9097e7883570e0b02bfbe6869cc25d8a3",
+    "rei": "0x2a1f38c9097e7883570e0b02bfbe6869cc25d8a3",
+    "seqInbox": "0x2a1f38c9097e7883570e0b02bfbe6869cc25d8a3"
   },
   "settings": {
     "challengeGracePeriodBlocks": 10,

--- a/contracts/scripts/files/localConfig.json
+++ b/contracts/scripts/files/localConfig.json
@@ -1,19 +1,19 @@
 {
   "contracts": {
-    "l1Timelock": "0x9c14dfd8e5c262f9652e78f2b0a13389ee41d717",
-    "rollup": "0x9c14dfd8e5c262f9652e78f2b0a13389ee41d717",
-    "bridge": "0x9B4477cAD544fB092B1Bc551d88465f7F13a443F",
-    "sequencerInbox": "0xD2B20a3B8C1d97A64eFA1120D3339d87841ccAE1",
-    "rollupEventInbox": "0xceb757a40f43905fbb7fc401ae0e17bd9fa95b3e",
-    "outbox": "0xbBaAB28Ad701e822148411376975cca7E02323d7",
-    "inbox": "0xa5d8d368c4Fc06D71724d91561d6F2a880FD4fD9",
-    "upgradeExecutor": "0x3e39ba62d5d0266102036f138e2a822ac7551e4f"
+    "l1Timelock": "0x6900354cF23D12A2c3cc98F48F1a28f9e3Ca1029",
+    "bridge": "0x6900354cF23D12A2c3cc98F48F1a28f9e3Ca1029",
+    "inbox": "0xAc4C9Ac691E928C3D004773efc9CA4Ca76747a2e",
+    "outbox": "0xa5f95320288c773fe9e568a404c7A4305a75C70A",
+    "rollup": "0x23a0311dc615bae798666c73500bdca005eefbcf",
+    "sequencerInbox": "0xd7EEdf4eA5dE1868EB825c39fb0d2cbE2d0EFdC0",
+    "rollupEventInbox": "0x23f10f9725ab85ebe53e452d6e3e8b165a4d5eef",
+    "upgradeExecutor": "0xfb0a643101012625fa222ce07c75e3a53381f1a9"
   },
   "proxyAdmins": {
-    "outbox": "0xffb9ce193d5fe12360f47a93a97d72da65c35019",
-    "bridge": "0xffb9ce193d5fe12360f47a93a97d72da65c35019",
-    "rei": "0xffb9ce193d5fe12360f47a93a97d72da65c35019",
-    "seqInbox": "0xffb9ce193d5fe12360f47a93a97d72da65c35019"
+    "outbox": "0x05485096e90ea515807b233e26758705d93b3b7a",
+    "bridge": "0x05485096e90ea515807b233e26758705d93b3b7a",
+    "rei": "0x05485096e90ea515807b233e26758705d93b3b7a",
+    "seqInbox": "0x05485096e90ea515807b233e26758705d93b3b7a"
   },
   "settings": {
     "challengeGracePeriodBlocks": 10,


### PR DESCRIPTION
bold upgrade CI test is broken because testnode addresses changed. 

for future reference, gathered addresses like this:
```
#!/bin/bash

PROXY_ADMIN_SLOT="0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103"

addresses=$(docker exec nitro-testnode-sequencer-1 cat /tokenbridge-data/l1l2_network.json)

contracts=$(echo $addresses | jq -r '.l2Network.ethBridge')
bridge=$(echo $contracts | jq -r '.bridge')

proxyAdmin=$(cast storage $bridge $PROXY_ADMIN_SLOT)
proxyAdmin="0x${proxyAdmin: -40}"

upgradeExecutor=$(cast call $proxyAdmin "owner()")
upgradeExecutor="0x${upgradeExecutor: -40}"

rollup=$(echo $contracts | jq -r '.rollup')
rollupEventInbox=$(cast call $rollup "rollupEventInbox()")
rollupEventInbox="0x${rollupEventInbox: -40}"

contracts=$(echo $contracts | jq ".rollupEventInbox = \"$rollupEventInbox\" | .upgradeExecutor = \"$upgradeExecutor\"")

# just set the timelock to the rollup, just used for excess stake
# script checks that it's a contract
contracts=$(echo $contracts | jq ".l1Timelock = \"$rollup\"")

echo "proxyAdmin: $proxyAdmin"

echo $contracts | jq
```