### PR TITLE
feat: fixed withdrawal address

### DIFF
--- a/contracts/src/rollup/IRollupCore.sol
+++ b/contracts/src/rollup/IRollupCore.sol
@@ -17,6 +17,7 @@ interface IRollupCore is IAssertionChain {
         bytes32 latestStakedAssertion;
         uint64 index;
         bool isStaked;
+        address withdrawalAddress;
     }
 
     event RollupInitialized(bytes32 machineHash, uint256 chainId);

--- a/contracts/src/rollup/IRollupCore.sol
+++ b/contracts/src/rollup/IRollupCore.sol
@@ -40,7 +40,7 @@ interface IRollupCore is IAssertionChain {
         uint64 indexed challengeIndex, address asserter, address challenger, uint64 challengedAssertion
     );
 
-    event UserStakeUpdated(address indexed user, uint256 initialBalance, uint256 finalBalance);
+    event UserStakeUpdated(address indexed user, address indexed withdrawalAddress, uint256 initialBalance, uint256 finalBalance);
 
     event UserWithdrawableFundsUpdated(address indexed user, uint256 initialBalance, uint256 finalBalance);
 

--- a/contracts/src/rollup/IRollupLogic.sol
+++ b/contracts/src/rollup/IRollupLogic.sol
@@ -41,5 +41,12 @@ interface IRollupUser is IRollupCore, IOwnable {
         bytes32 expectedAssertionHash
     ) external;
 
+    function newStakeOnNewAssertion(
+        uint256 tokenAmount,
+        AssertionInputs calldata assertion,
+        bytes32 expectedAssertionHash,
+        address withdrawalAddress
+    ) external;
+
     function addToDeposit(address stakerAddress, uint256 tokenAmount) external;
 }

--- a/contracts/src/rollup/RollupCore.sol
+++ b/contracts/src/rollup/RollupCore.sol
@@ -275,7 +275,7 @@ abstract contract RollupCore is IRollupCore, PausableUpgradeable {
         uint64 stakerIndex = uint64(_stakerList.length);
         _stakerList.push(stakerAddress);
         _stakerMap[stakerAddress] = Staker(depositAmount, _latestConfirmed, stakerIndex, true, withdrawalAddress);
-        emit UserStakeUpdated(stakerAddress, 0, depositAmount);
+        emit UserStakeUpdated(stakerAddress, withdrawalAddress, 0, depositAmount);
     }
 
     /**
@@ -288,7 +288,7 @@ abstract contract RollupCore is IRollupCore, PausableUpgradeable {
         uint256 initialStaked = staker.amountStaked;
         uint256 finalStaked = initialStaked + amountAdded;
         staker.amountStaked = finalStaked;
-        emit UserStakeUpdated(stakerAddress, initialStaked, finalStaked);
+        emit UserStakeUpdated(stakerAddress, staker.withdrawalAddress, initialStaked, finalStaked);
     }
 
     /**
@@ -305,7 +305,7 @@ abstract contract RollupCore is IRollupCore, PausableUpgradeable {
         uint256 amountWithdrawn = current - target;
         staker.amountStaked = target;
         increaseWithdrawableFunds(withdrawalAddress, amountWithdrawn);
-        emit UserStakeUpdated(stakerAddress, current, target);
+        emit UserStakeUpdated(stakerAddress, withdrawalAddress, current, target);
         return amountWithdrawn;
     }
 
@@ -320,7 +320,7 @@ abstract contract RollupCore is IRollupCore, PausableUpgradeable {
         uint256 initialStaked = staker.amountStaked;
         increaseWithdrawableFunds(withdrawalAddress, initialStaked);
         deleteStaker(stakerAddress);
-        emit UserStakeUpdated(stakerAddress, initialStaked, 0);
+        emit UserStakeUpdated(stakerAddress, withdrawalAddress, initialStaked, 0);
     }
 
     /**

--- a/contracts/src/rollup/RollupUserLogic.sol
+++ b/contracts/src/rollup/RollupUserLogic.sol
@@ -310,7 +310,8 @@ contract RollupUserLogic is RollupCore, UUPSNotUpgradeable, IRollupUser {
     }
 
     /**
-     * @notice Deprecated, 
+     * @notice Deprecated, use the function with `withdrawalAddress` instead
+     *         Using this default `withdrawalAddress` to msg.sender
      */
     function newStakeOnNewAssertion(
         uint256 tokenAmount,

--- a/contracts/src/rollup/RollupUserLogic.sol
+++ b/contracts/src/rollup/RollupUserLogic.sol
@@ -134,11 +134,11 @@ contract RollupUserLogic is RollupCore, UUPSNotUpgradeable, IRollupUser {
      * @notice Create a new stake
      * @param depositAmount The amount of either eth or tokens staked
      */
-    function _newStake(uint256 depositAmount) internal onlyValidator whenNotPaused {
+    function _newStake(uint256 depositAmount, address withdrawalAddress) internal onlyValidator whenNotPaused {
         // Verify that sender is not already a staker
         require(!isStaked(msg.sender), "ALREADY_STAKED");
         // amount will be checked when creating an assertion
-        createNewStake(msg.sender, depositAmount);
+        createNewStake(msg.sender, depositAmount, withdrawalAddress);
     }
 
     /**
@@ -310,17 +310,31 @@ contract RollupUserLogic is RollupCore, UUPSNotUpgradeable, IRollupUser {
     }
 
     /**
-     * @notice Create a new stake on a new assertion
-     * @param tokenAmount Amount of the rollups staking token to stake
-     * @param assertion Assertion describing the state change between the old assertion and the new one
-     * @param expectedAssertionHash Assertion hash of the assertion that will be created
+     * @notice Deprecated, 
      */
     function newStakeOnNewAssertion(
         uint256 tokenAmount,
         AssertionInputs calldata assertion,
         bytes32 expectedAssertionHash
     ) external {
-        _newStake(tokenAmount);
+        newStakeOnNewAssertion(tokenAmount, assertion, expectedAssertionHash, msg.sender);
+    }
+
+    /**
+     * @notice Create a new stake on a new assertion
+     * @param tokenAmount Amount of the rollups staking token to stake
+     * @param assertion Assertion describing the state change between the old assertion and the new one
+     * @param expectedAssertionHash Assertion hash of the assertion that will be created
+     * @param withdrawalAddress The address the send the stake back upon withdrawal
+     */
+    function newStakeOnNewAssertion(
+        uint256 tokenAmount,
+        AssertionInputs calldata assertion,
+        bytes32 expectedAssertionHash,
+        address withdrawalAddress
+    ) public {
+        require(withdrawalAddress != address(0), "EMPTY_WITHDRAWAL_ADDRESS");
+        _newStake(tokenAmount, withdrawalAddress);
         stakeOnNewAssertion(assertion, expectedAssertionHash);
         /// @dev This is an external call, safe because it's at the end of the function
         receiveTokens(tokenAmount);

--- a/contracts/test/Rollup.t.sol
+++ b/contracts/test/Rollup.t.sol
@@ -36,6 +36,9 @@ contract RollupTest is Test {
     address constant validator1 = address(100001);
     address constant validator2 = address(100002);
     address constant validator3 = address(100003);
+    address constant validator1Withdrawal = address(1000010);
+    address constant validator2Withdrawal = address(1000020);
+    address constant validator3Withdrawal = address(1000030);
     address constant loserStakeEscrow = address(200001);
     address constant anyTrustFastConfirmer = address(300001);
 
@@ -371,7 +374,8 @@ contract RollupTest is Test {
                 beforeState: beforeState,
                 afterState: afterState
             }),
-            expectedAssertionHash: expectedAssertionHash
+            expectedAssertionHash: expectedAssertionHash,
+            withdrawalAddress: validator1Withdrawal
         });
 
         return (expectedAssertionHash, afterState, inboxcount);
@@ -419,7 +423,8 @@ contract RollupTest is Test {
                 beforeState: beforeState,
                 afterState: afterState
             }),
-            expectedAssertionHash: expectedAssertionHash
+            expectedAssertionHash: expectedAssertionHash,
+            withdrawalAddress: validator1Withdrawal
         });
 
         return (expectedAssertionHash, afterState, inboxcount);
@@ -453,7 +458,8 @@ contract RollupTest is Test {
                 beforeState: beforeState,
                 afterState: afterState
             }),
-            expectedAssertionHash: bytes32(0)
+            expectedAssertionHash: bytes32(0),
+            withdrawalAddress: validator1Withdrawal
         });
 
         vm.prank(validator2);
@@ -475,7 +481,8 @@ contract RollupTest is Test {
                 beforeState: beforeState,
                 afterState: afterState
             }),
-            expectedAssertionHash: bytes32(0)
+            expectedAssertionHash: bytes32(0),
+            withdrawalAddress: validator2Withdrawal
         });
     }
 
@@ -514,7 +521,8 @@ contract RollupTest is Test {
                 beforeState: beforeState,
                 afterState: afterState
             }),
-            expectedAssertionHash: expectedAssertionHash
+            expectedAssertionHash: expectedAssertionHash,
+            withdrawalAddress: validator1Withdrawal
         });
 
         AssertionState memory afterState2;
@@ -613,7 +621,8 @@ contract RollupTest is Test {
                 beforeState: beforeState,
                 afterState: afterState
             }),
-            expectedAssertionHash: expectedAssertionHash
+            expectedAssertionHash: expectedAssertionHash,
+            withdrawalAddress: validator1Withdrawal
         });
 
         AssertionState memory afterState2;
@@ -655,7 +664,8 @@ contract RollupTest is Test {
                 }),
                 afterState: afterState2
             }),
-            expectedAssertionHash: expectedAssertionHash2
+            expectedAssertionHash: expectedAssertionHash2,
+            withdrawalAddress: validator2Withdrawal
         });
 
         assertEq(userRollup.getAssertion(genesisHash).secondChildBlock, block.number);
@@ -707,7 +717,8 @@ contract RollupTest is Test {
                 }),
                 afterState: afterState3
             }),
-            expectedAssertionHash: expectedAssertionHash3
+            expectedAssertionHash: expectedAssertionHash3,
+            withdrawalAddress: validator3Withdrawal
         });
     }
 
@@ -943,8 +954,8 @@ contract RollupTest is Test {
         testSuccessConfirmEdgeByTime();
         vm.prank(validator1);
         userRollup.returnOldDeposit();
-        assertGt(userRollup.withdrawableFunds(validator1), 0);
-        vm.prank(validator1);
+        assertGt(userRollup.withdrawableFunds(validator1Withdrawal), 0);
+        vm.prank(validator1Withdrawal);
         userRollup.withdrawStakerFunds();
     }
 
@@ -1147,7 +1158,8 @@ contract RollupTest is Test {
             userRollup.newStakeOnNewAssertion({
                 tokenAmount: BASE_STAKE,
                 assertion: assertion,
-                expectedAssertionHash: expectedAssertionHash
+                expectedAssertionHash: expectedAssertionHash,
+                withdrawalAddress: validator1Withdrawal
             });
         }
 

--- a/contracts/test/Rollup.t.sol
+++ b/contracts/test/Rollup.t.sol
@@ -959,8 +959,10 @@ contract RollupTest is Test {
         assertEq(keccak256(abi.encode(emptyStaker)), keccak256(abi.encode(userRollup.getStaker(validator1))));
 
         assertGt(userRollup.withdrawableFunds(validator1Withdrawal), 0);
+        assertEq(token.balanceOf(validator1Withdrawal), 0);
         vm.prank(validator1Withdrawal);
         userRollup.withdrawStakerFunds();
+        assertEq(token.balanceOf(validator1Withdrawal), BASE_STAKE);
     }
 
     function testRevertWithdrawActiveStake() public {

--- a/contracts/test/Rollup.t.sol
+++ b/contracts/test/Rollup.t.sol
@@ -996,6 +996,19 @@ contract RollupTest is Test {
         });
     }
 
+    function testRevertZeroWithdrawalAddress() public {
+        testSuccessCreateAssertion();
+        vm.prank(validator1);
+        AssertionInputs memory emptyAssertion;
+        vm.expectRevert("EMPTY_WITHDRAWAL_ADDRESS");
+        userRollup.newStakeOnNewAssertion({
+            tokenAmount: BASE_STAKE,
+            assertion: emptyAssertion,
+            expectedAssertionHash: bytes32(0),
+            withdrawalAddress: address(0)
+        });
+    }
+
     function testSuccessReduceDeposit() public {
         testSuccessConfirmEdgeByTime();
         vm.prank(validator1);

--- a/contracts/test/Rollup.t.sol
+++ b/contracts/test/Rollup.t.sol
@@ -954,6 +954,10 @@ contract RollupTest is Test {
         testSuccessConfirmEdgeByTime();
         vm.prank(validator1);
         userRollup.returnOldDeposit();
+
+        RollupCore.Staker memory emptyStaker;
+        assertEq(keccak256(abi.encode(emptyStaker)), keccak256(abi.encode(userRollup.getStaker(validator1))));
+
         assertGt(userRollup.withdrawableFunds(validator1Withdrawal), 0);
         vm.prank(validator1Withdrawal);
         userRollup.withdrawStakerFunds();
@@ -977,6 +981,19 @@ contract RollupTest is Test {
         vm.prank(loserStakeEscrow);
         vm.expectRevert("NO_FUNDS_TO_WITHDRAW");
         userRollup.withdrawStakerFunds();
+    }
+
+    function testRevertAlreadyStaked() public {
+        testSuccessCreateAssertion();
+        vm.prank(validator1);
+        AssertionInputs memory emptyAssertion;
+        vm.expectRevert("ALREADY_STAKED");
+        userRollup.newStakeOnNewAssertion({
+            tokenAmount: BASE_STAKE,
+            assertion: emptyAssertion,
+            expectedAssertionHash: bytes32(0),
+            withdrawalAddress: validator2Withdrawal
+        });
     }
 
     function testSuccessReduceDeposit() public {

--- a/contracts/test/signatures/RollupUserLogic
+++ b/contracts/test/signatures/RollupUserLogic
@@ -32,6 +32,7 @@
   "loserStakeEscrow()": "f065de3f",
   "minimumAssertionPeriod()": "45e38b64",
   "newStakeOnNewAssertion(uint256,((bytes32,bytes32,(bytes32,uint256,address,uint64,uint64)),((bytes32[2],uint64[2]),uint8,bytes32),((bytes32[2],uint64[2]),uint8,bytes32)),bytes32)": "7300201c",
+  "newStakeOnNewAssertion(uint256,((bytes32,bytes32,(bytes32,uint256,address,uint64,uint64)),((bytes32[2],uint64[2]),uint8,bytes32),((bytes32[2],uint64[2]),uint8,bytes32)),bytes32,address)": "50f32f68",
   "outbox()": "ce11e6ab",
   "owner()": "8da5cb5b",
   "paused()": "5c975abb",


### PR DESCRIPTION
This PR introduce a feature to pin a withdrawal address on creating a new stake (similar to how beacon chain withdrawal credential works), and thus reducing this risk of having a hot private key in the validator software. Note that a compromised key can still lead to a full slashing.

Withdrawal address can only be changed upon full unstake.

TODO: events, tests