### PR TITLE
Throw `EdgeNotPending` instead of `RivalEdgeConfirmed` when trying to confirm an already confirmed edge

### DIFF
--- a/contracts/src/challengeV2/libraries/EdgeChallengeManagerLib.sol
+++ b/contracts/src/challengeV2/libraries/EdgeChallengeManagerLib.sol
@@ -725,11 +725,11 @@ library EdgeChallengeManagerLib {
             revert InsufficientConfirmationBlocks(totalTimeUnrivaled, confirmationThresholdBlock);
         }
 
-        // also checks that no other rival has been confirmed
-        setConfirmedRival(store, edgeId);
-
         // we also check the edge is pending in setConfirmed()
         store.edges[edgeId].setConfirmed();
+        
+        // also checks that no other rival has been confirmed
+        setConfirmedRival(store, edgeId);
 
         return totalTimeUnrivaled;
     }

--- a/contracts/test/challengeV2/EdgeChallengeManager.t.sol
+++ b/contracts/test/challengeV2/EdgeChallengeManager.t.sol
@@ -651,6 +651,13 @@ contract EdgeChallengeManagerTest is Test {
         );
     }
 
+    function testCantConfirmEdgeByTimeTwice() public {
+        (EdgeInitData memory ei, bytes32 edge1Id) = testCanConfirmByChildren();
+
+        vm.expectRevert(abi.encodeWithSelector(EdgeNotPending.selector, edge1Id, EdgeStatus.Confirmed));
+        ei.challengeManager.confirmEdgeByTime(edge1Id, ei.a1Data);
+    }
+
     function bisect(
         EdgeChallengeManager challengeManager,
         bytes32 edgeId,


### PR DESCRIPTION
previously, if you try to confirm an edge that was already confirmed, you'd get `RivalEdgeConfirmed(0x123,0x123)`, which is misleading (and scary) at first glance.

reordering 2 internal calls will result in an `EdgeNotPending` error instead, which is more accurate.