### PR TITLE
feat: direct send to loserStakeEscrow

### DIFF
--- a/contracts/src/rollup/RollupUserLogic.sol
+++ b/contracts/src/rollup/RollupUserLogic.sol
@@ -212,7 +212,7 @@ contract RollupUserLogic is RollupCore, UUPSNotUpgradeable, IRollupUser {
             // only 1 of the children can be confirmed and get their stake refunded
             // so we send the other children's stake to the loserStakeEscrow
             // NOTE: if the losing staker have staked more than requiredStake, the excess stake will be stuck
-            increaseWithdrawableFunds(loserStakeEscrow, assertion.beforeStateData.configData.requiredStake);
+            IERC20(stakeToken).safeTransfer(loserStakeEscrow, assertion.beforeStateData.configData.requiredStake);
         }
     }
 
@@ -292,7 +292,7 @@ contract RollupUserLogic is RollupCore, UUPSNotUpgradeable, IRollupUser {
                 // only 1 of the children can be confirmed and get their stake refunded
                 // so we send the other children's stake to the loserStakeEscrow
                 // NOTE: if the losing staker have staked more than requiredStake, the excess stake will be stuck
-                increaseWithdrawableFunds(loserStakeEscrow, assertion.beforeStateData.configData.requiredStake);
+                IERC20(stakeToken).safeTransfer(loserStakeEscrow, assertion.beforeStateData.configData.requiredStake);
             }
         }
 

--- a/contracts/test/Rollup.t.sol
+++ b/contracts/test/Rollup.t.sol
@@ -976,16 +976,10 @@ contract RollupTest is Test {
     }
 
     function testSuccessWithdrawExcessStake() public {
+        uint256 prevBal = token.balanceOf(loserStakeEscrow);
         testSuccessCreateSecondChild();
-        vm.prank(loserStakeEscrow);
-        userRollup.withdrawStakerFunds();
-    }
-
-    function testRevertWithdrawNoExcessStake() public {
-        testSuccessCreateAssertion();
-        vm.prank(loserStakeEscrow);
-        vm.expectRevert("NO_FUNDS_TO_WITHDRAW");
-        userRollup.withdrawStakerFunds();
+        uint256 afterBal = token.balanceOf(loserStakeEscrow);
+        assertEq(afterBal - prevBal, BASE_STAKE, "loser stake not sent to escrow");
     }
 
     function testRevertAlreadyStaked() public {


### PR DESCRIPTION
Alternative to https://github.com/OffchainLabs/bold/pull/633

This will add the assumption that an attacker cannot cause the stakeToken transfer to revert, which I think is ok. It should already be an assumption otherwise an attacker may simply prevent the honest validator from staking. The only exception would be if there is an accounting issue causing the contract to have insufficient balance, but that would be a problem on its own.