### PR TITLE
Merge stylus ecb46c1f to 77ee9de0

### DIFF
--- a/contracts/src/precompiles/ArbOwner.sol
+++ b/contracts/src/precompiles/ArbOwner.sol
@@ -105,9 +105,6 @@ interface ArbOwner {
     /// @notice Sets the base cost of each additional wasm page
     function setWasmPageGas(uint16 gas) external;
 
-    /// @notice Sets the ramp that drives exponential wasm memory costs
-    function setWasmPageRamp(uint64 ramp) external;
-
     /// @notice Sets the maximum number of pages a wasm may allocate
     function setWasmPageLimit(uint16 limit) external;
 
@@ -115,6 +112,10 @@ interface ArbOwner {
     /// @param gas amount of gas paid in increments of 256 when not the program is not cached
     /// @param cached amount of gas paid in increments of 64 when the program is cached
     function setWasmMinInitGas(uint8 gas, uint16 cached) external;
+
+    /// @notice Sets the linear adjustment made to program init costs.
+    /// @param percent the adjustment (100% = no adjustment).
+    function setWasmInitCostScalar(uint64 percent) external;
 
     /// @notice Sets the number of days after which programs deactivate
     function setWasmExpiryDays(uint16 _days) external;

--- a/contracts/src/precompiles/ArbWasm.sol
+++ b/contracts/src/precompiles/ArbWasm.sol
@@ -39,13 +39,13 @@ interface ArbWasm {
     /// @return version the program version (reverts for EVM contracts)
     function programVersion(address program) external view returns (uint16 version);
 
-    /// @notice Gets the cost to invoke the program (not including minInitGas)
+    /// @notice Gets the cost to invoke the program
     /// @return gas the amount of gas
     /// @return gasWhenCached the amount of gas if the program was recently used
     function programInitGas(address program)
         external
         view
-        returns (uint16 gas, uint16 gasWhenCached);
+        returns (uint64 gas, uint64 gasWhenCached);
 
     /// @notice Gets the memory footprint of the program at the given address in pages
     /// @return footprint the memory footprint of program in pages (reverts for EVM contracts)
@@ -83,6 +83,10 @@ interface ArbWasm {
     /// @return gas amount of gas in increments of 256 when not cached
     /// @return cached amount of gas in increments of 64 when cached
     function minInitGas() external view returns (uint8 gas, uint8 cached);
+
+    /// @notice Gets the linear adjustment made to program init costs.
+    /// @return percent the adjustment (100% = no adjustment).
+    function initCostScalar() external view returns (uint64 percent);
 
     /// @notice Gets the number of days after which programs deactivate
     /// @return _days the number of days

--- a/contracts/src/state/Deserialize.sol
+++ b/contracts/src/state/Deserialize.sol
@@ -232,17 +232,20 @@ library Deserialize {
         ModuleMemory memory mem;
         bytes32 tablesMerkleRoot;
         bytes32 functionsMerkleRoot;
+        bytes32 extraHash;
         uint32 internalsOffset;
         (globalsMerkleRoot, offset) = b32(proof, offset);
         (mem, offset) = moduleMemory(proof, offset);
         (tablesMerkleRoot, offset) = b32(proof, offset);
         (functionsMerkleRoot, offset) = b32(proof, offset);
+        (extraHash, offset) = b32(proof, offset);
         (internalsOffset, offset) = u32(proof, offset);
         mod = Module({
             globalsMerkleRoot: globalsMerkleRoot,
             moduleMemory: mem,
             tablesMerkleRoot: tablesMerkleRoot,
             functionsMerkleRoot: functionsMerkleRoot,
+            extraHash: extraHash,
             internalsOffset: internalsOffset
         });
     }

--- a/contracts/src/state/Module.sol
+++ b/contracts/src/state/Module.sol
@@ -11,6 +11,7 @@ struct Module {
     ModuleMemory moduleMemory;
     bytes32 tablesMerkleRoot;
     bytes32 functionsMerkleRoot;
+    bytes32 extraHash;
     uint32 internalsOffset;
 }
 
@@ -26,6 +27,7 @@ library ModuleLib {
                     mod.moduleMemory.hash(),
                     mod.tablesMerkleRoot,
                     mod.functionsMerkleRoot,
+                    mod.extraHash,
                     mod.internalsOffset
                 )
             );


### PR DESCRIPTION
changes from ecb46c1f to 77ee9de0 in nitro-contracts

(i ignored `src/challenge`, non `sol` files, and tests)