### PR TITLE
Fast Sync a Validator While Chain Watcher Catching Up

### DIFF
--- a/challenge-manager/chain-watcher/watcher.go
+++ b/challenge-manager/chain-watcher/watcher.go
@@ -233,8 +233,6 @@ func (w *Watcher) Start(ctx context.Context) {
 		return
 	}
 
-	w.initialSyncCompleted.Store(true)
-
 	fromBlock = toBlock
 	ticker := time.NewTicker(w.pollEventsInterval)
 	defer ticker.Stop()
@@ -252,6 +250,8 @@ func (w *Watcher) Start(ctx context.Context) {
 			}
 			toBlock := latestBlock.Number.Uint64()
 			if fromBlock == toBlock {
+				w.initialSyncCompleted.Store(true)
+				log.Info("BOLD chain event scraper caught up to latest block", "blockNum", toBlock)
 				continue
 			}
 			// Get a challenge manager instance and filterer.


### PR DESCRIPTION
While our chain watcher is scraping events from the latest confirmed assertion to chain head, we want to have our edge trackers "act" as fast as it is reasonable (1s). Then, once we are caught up, we instead just have edge trackers act on each new block notification