### PR TITLE
Fix Assertion Posting / Confirmation Reverts

### DIFF
--- a/api/backend/BUILD.bazel
+++ b/api/backend/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//challenge-manager/chain-watcher",
         "//challenge-manager/edge-tracker",
         "//containers/option",
+        "@com_github_ethereum_go_ethereum//accounts/abi/bind",
         "@com_github_ethereum_go_ethereum//common",
     ],
 )

--- a/api/backend/backend.go
+++ b/api/backend/backend.go
@@ -275,7 +275,7 @@ func (b *Backend) GetTrackedRoyalEdges(ctx context.Context) ([]*api.JsonEdgesByC
 }
 
 func (b *Backend) LatestConfirmedAssertion(ctx context.Context) (*api.JsonAssertion, error) {
-	latestConfirmedAssertion, err := b.chainDataFetcher.LatestConfirmed(ctx)
+	latestConfirmedAssertion, err := b.chainDataFetcher.LatestConfirmed(ctx, &bind.CallOpts{Context: ctx})
 	if err != nil {
 		return nil, err
 	}

--- a/api/backend/backend.go
+++ b/api/backend/backend.go
@@ -16,6 +16,7 @@ import (
 	watcher "github.com/OffchainLabs/bold/challenge-manager/chain-watcher"
 	edgetracker "github.com/OffchainLabs/bold/challenge-manager/edge-tracker"
 	"github.com/OffchainLabs/bold/containers/option"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -64,7 +65,7 @@ func (b *Backend) GetAssertions(ctx context.Context, opts ...db.AssertionOption)
 	}
 	if query.ShouldForceUpdate() {
 		for _, a := range assertions {
-			fetchedAssertion, err := b.chainDataFetcher.GetAssertion(ctx, protocol.AssertionHash{Hash: a.Hash})
+			fetchedAssertion, err := b.chainDataFetcher.GetAssertion(ctx, &bind.CallOpts{Context: ctx}, protocol.AssertionHash{Hash: a.Hash})
 			if err != nil {
 				return nil, err
 			}
@@ -287,7 +288,7 @@ func (b *Backend) LatestConfirmedAssertion(ctx context.Context) (*api.JsonAssert
 	if err != nil {
 		return nil, err
 	}
-	fetchedAssertion, err := b.chainDataFetcher.GetAssertion(ctx, hash)
+	fetchedAssertion, err := b.chainDataFetcher.GetAssertion(ctx, &bind.CallOpts{Context: ctx}, hash)
 	if err != nil {
 		return nil, err
 	}

--- a/assertions/confirmation.go
+++ b/assertions/confirmation.go
@@ -11,6 +11,7 @@ import (
 	"github.com/OffchainLabs/bold/challenge-manager/types"
 	"github.com/OffchainLabs/bold/containers/option"
 	retry "github.com/OffchainLabs/bold/runtime"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -51,7 +52,11 @@ func (m *Manager) keepTryingAssertionConfirmation(ctx context.Context, assertion
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			parentAssertion, err := m.chain.GetAssertion(ctx, protocol.AssertionHash{Hash: creationInfo.ParentAssertionHash})
+			parentAssertion, err := m.chain.GetAssertion(
+				ctx,
+				m.chain.GetCallOptsWithDesiredRpcHeadBlockNumber(&bind.CallOpts{Context: ctx}),
+				protocol.AssertionHash{Hash: creationInfo.ParentAssertionHash},
+			)
 			if err != nil {
 				log.Error("Could not get parent assertion", "err", err)
 				continue

--- a/assertions/confirmation.go
+++ b/assertions/confirmation.go
@@ -93,7 +93,7 @@ func (m *Manager) updateLatestConfirmedMetrics(ctx context.Context) {
 	for {
 		select {
 		case <-ticker.C:
-			latestConfirmed, err := m.chain.LatestConfirmed(ctx)
+			latestConfirmed, err := m.chain.LatestConfirmed(ctx, m.chain.GetCallOptsWithDesiredRpcHeadBlockNumber(&bind.CallOpts{Context: ctx}))
 			if err != nil {
 				log.Debug("Could not fetch latest confirmed assertion", "err", err)
 				continue

--- a/assertions/sync.go
+++ b/assertions/sync.go
@@ -520,7 +520,7 @@ func (m *Manager) saveAssertionToDB(ctx context.Context, creationInfo *protocol.
 	if err != nil {
 		return err
 	}
-	assertion, err := m.chain.GetAssertion(ctx, assertionHash)
+	assertion, err := m.chain.GetAssertion(ctx, &bind.CallOpts{Context: ctx}, assertionHash)
 	if err != nil {
 		return err
 	}

--- a/assertions/sync.go
+++ b/assertions/sync.go
@@ -20,7 +20,7 @@ import (
 
 func (m *Manager) syncAssertions(ctx context.Context) {
 	latestConfirmed, err := retry.UntilSucceeds(ctx, func() (protocol.Assertion, error) {
-		return m.chain.LatestConfirmed(ctx)
+		return m.chain.LatestConfirmed(ctx, m.chain.GetCallOptsWithDesiredRpcHeadBlockNumber(&bind.CallOpts{Context: ctx}))
 	})
 	if err != nil {
 		log.Error("Could not get latest confirmed assertion", "err", err)

--- a/chain-abstraction/interfaces.go
+++ b/chain-abstraction/interfaces.go
@@ -138,7 +138,7 @@ type AssertionChain interface {
 		ctx context.Context,
 		assertionHash AssertionHash,
 	) (AssertionStatus, error)
-	LatestConfirmed(ctx context.Context) (Assertion, error)
+	LatestConfirmed(ctx context.Context, opts *bind.CallOpts) (Assertion, error)
 	ReadAssertionCreationInfo(
 		ctx context.Context, id AssertionHash,
 	) (*AssertionCreatedInfo, error)

--- a/chain-abstraction/interfaces.go
+++ b/chain-abstraction/interfaces.go
@@ -131,7 +131,7 @@ type AssertionChain interface {
 	// Read-only methods.
 	IsStaked(ctx context.Context) (bool, error)
 	RollupUserLogic() *rollupgen.RollupUserLogic
-	GetAssertion(ctx context.Context, id AssertionHash) (Assertion, error)
+	GetAssertion(ctx context.Context, opts *bind.CallOpts, id AssertionHash) (Assertion, error)
 	IsChallengeComplete(ctx context.Context, challengeParentAssertionHash AssertionHash) (bool, error)
 	Backend() ChainBackend
 	AssertionStatus(

--- a/chain-abstraction/interfaces.go
+++ b/chain-abstraction/interfaces.go
@@ -139,8 +139,6 @@ type AssertionChain interface {
 		assertionHash AssertionHash,
 	) (AssertionStatus, error)
 	LatestConfirmed(ctx context.Context) (Assertion, error)
-	LatestCreatedAssertion(ctx context.Context) (Assertion, error)
-	LatestCreatedAssertionHashes(ctx context.Context) ([]AssertionHash, error)
 	ReadAssertionCreationInfo(
 		ctx context.Context, id AssertionHash,
 	) (*AssertionCreatedInfo, error)

--- a/chain-abstraction/sol-implementation/BUILD.bazel
+++ b/chain-abstraction/sol-implementation/BUILD.bazel
@@ -63,7 +63,6 @@ go_test(
         "@com_github_ethereum_go_ethereum//:go-ethereum",
         "@com_github_ethereum_go_ethereum//accounts/abi",
         "@com_github_ethereum_go_ethereum//accounts/abi/bind",
-        "@com_github_ethereum_go_ethereum//accounts/abi/bind/backends",
         "@com_github_ethereum_go_ethereum//common",
         "@com_github_ethereum_go_ethereum//core/types",
         "@com_github_stretchr_testify//require",

--- a/chain-abstraction/sol-implementation/assertion_chain_test.go
+++ b/chain-abstraction/sol-implementation/assertion_chain_test.go
@@ -17,12 +17,9 @@ import (
 	"github.com/OffchainLabs/bold/solgen/go/mocksgen"
 	challenge_testing "github.com/OffchainLabs/bold/testing"
 	"github.com/OffchainLabs/bold/testing/setup"
-	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -507,14 +504,4 @@ func TestIsChallengeComplete(t *testing.T) {
 	chalComplete, err = chain.IsChallengeComplete(ctx, challengeParentAssertionHash)
 	require.NoError(t, err)
 	require.Equal(t, true, chalComplete)
-}
-
-type mockBackend struct {
-	*backends.SimulatedBackend
-
-	logs []types.Log
-}
-
-func (mb *mockBackend) FilterLogs(ctx context.Context, query ethereum.FilterQuery) ([]types.Log, error) {
-	return mb.logs, nil
 }

--- a/chain-abstraction/sol-implementation/assertion_chain_test.go
+++ b/chain-abstraction/sol-implementation/assertion_chain_test.go
@@ -15,7 +15,6 @@ import (
 	l2stateprovider "github.com/OffchainLabs/bold/layer2-state-provider"
 	"github.com/OffchainLabs/bold/solgen/go/bridgegen"
 	"github.com/OffchainLabs/bold/solgen/go/mocksgen"
-	"github.com/OffchainLabs/bold/solgen/go/rollupgen"
 	challenge_testing "github.com/OffchainLabs/bold/testing"
 	"github.com/OffchainLabs/bold/testing/setup"
 	"github.com/ethereum/go-ethereum"
@@ -351,7 +350,7 @@ func TestConfirmAssertionByChallengeWinner(t *testing.T) {
 
 	chain := createdData.Chains[0]
 
-	latestConfirmed, err := chain.LatestConfirmed(ctx)
+	latestConfirmed, err := chain.LatestConfirmed(ctx, &bind.CallOpts{Context: ctx})
 	require.NoError(t, err)
 
 	t.Run("genesis case", func(t *testing.T) {
@@ -380,7 +379,7 @@ func TestConfirmAssertionByChallengeWinner(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		latestConfirmed, err = chain.LatestConfirmed(ctx)
+		latestConfirmed, err = chain.LatestConfirmed(ctx, &bind.CallOpts{Context: ctx})
 		require.NoError(t, err)
 		require.Equal(t, createdData.Leaf1.Id(), latestConfirmed.Id())
 
@@ -397,7 +396,7 @@ func TestAssertionBySequenceNum(t *testing.T) {
 	cfg, err := setup.ChainsWithEdgeChallengeManager()
 	require.NoError(t, err)
 	chain := cfg.Chains[0]
-	latestConfirmed, err := chain.LatestConfirmed(ctx)
+	latestConfirmed, err := chain.LatestConfirmed(ctx, &bind.CallOpts{Context: ctx})
 	require.NoError(t, err)
 	opts := &bind.CallOpts{Context: ctx}
 	_, err = chain.GetAssertion(ctx, opts, latestConfirmed.Id())
@@ -518,187 +517,4 @@ type mockBackend struct {
 
 func (mb *mockBackend) FilterLogs(ctx context.Context, query ethereum.FilterQuery) ([]types.Log, error) {
 	return mb.logs, nil
-}
-
-func TestLatestCreatedAssertion(t *testing.T) {
-	ctx := context.Background()
-	cfg, err := setup.ChainsWithEdgeChallengeManager()
-	require.NoError(t, err)
-	chain := cfg.Chains[0]
-
-	abi, err := rollupgen.RollupCoreMetaData.GetAbi()
-	if err != nil {
-		t.Fatal(err)
-	}
-	abiEvt := abi.Events["AssertionCreated"]
-
-	packLog := func(evt *rollupgen.RollupCoreAssertionCreated) []byte {
-		// event AssertionCreated(
-		// 	bytes32 indexed assertionHash,
-		// 	bytes32 indexed parentAssertionHash,
-		// 	AssertionInputs assertion,
-		// 	bytes32 afterInboxBatchAcc,
-		// 	uint256 inboxMaxCount,
-		// 	bytes32 wasmModuleRoot,
-		// 	uint256 requiredStake,
-		// 	address challengeManager,
-		// 	uint64 confirmPeriodBlocks
-		// );
-		d, packErr := abiEvt.Inputs.Pack(
-			evt.AssertionHash,
-			evt.ParentAssertionHash,
-			// Non-indexed fields.
-			evt.Assertion,
-			evt.AfterInboxBatchAcc,
-			evt.InboxMaxCount,
-			evt.WasmModuleRoot,
-			evt.RequiredStake,
-			evt.ChallengeManager,
-			evt.ConfirmPeriodBlocks,
-		)
-
-		if packErr != nil {
-			t.Fatal(packErr)
-		}
-
-		return d
-	}
-
-	// Minimal event data.
-	// Note: *big.Int values cannot be nil.
-	latest := &rollupgen.RollupCoreAssertionCreated{
-		Assertion: rollupgen.AssertionInputs{
-			BeforeStateData: rollupgen.BeforeStateData{
-				ConfigData: rollupgen.ConfigData{RequiredStake: big.NewInt(0)},
-			},
-		},
-		InboxMaxCount: big.NewInt(0),
-		RequiredStake: big.NewInt(0),
-	}
-
-	// Use the latest confirmed assertion as the last assertion.
-	expected, err := chain.LatestConfirmed(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var latestAssertionID [32]byte
-	copy(latestAssertionID[:], expected.Id().Bytes())
-	var fakeAssertionID [32]byte
-	copy(fakeAssertionID[:], []byte("fake assertion id as parent"))
-
-	evtID := abiEvt.ID
-	validTopics := []common.Hash{evtID, latestAssertionID, fakeAssertionID}
-	// Invalid topics will return an error when trying to lookup an assertion with the fake ID.
-	invalidTopics := []common.Hash{evtID, fakeAssertionID, fakeAssertionID}
-
-	// The backend is bad and sent logs in the wrong order and also
-	// sent "removed" logs from a nasty reorg.
-	logs := []types.Log{
-		{
-			BlockNumber: 120,
-			Index:       0,
-			Topics:      invalidTopics,
-		}, {
-			BlockNumber: 119,
-			Index:       0,
-			Topics:      invalidTopics,
-		}, {
-			BlockNumber: 122,
-			Index:       4,
-			Topics:      invalidTopics,
-			Removed:     true,
-		},
-		{ // This is the latest created assertion.
-			BlockNumber: 122,
-			Index:       3,
-			Topics:      validTopics,
-			Data:        packLog(latest),
-		},
-		{
-			BlockNumber: 122,
-			Index:       2,
-			Topics:      invalidTopics,
-		}, {
-			BlockNumber: 120,
-			Index:       0,
-			Topics:      invalidTopics,
-		},
-	}
-
-	chain.SetBackend(&mockBackend{logs: logs})
-
-	latestCreated, err := chain.LatestCreatedAssertion(ctx)
-	require.NoError(t, err)
-
-	require.Equal(t, expected.Id().Hash, latestCreated.Id().Hash)
-}
-
-func TestLatestCreatedAssertionHashes(t *testing.T) {
-	ctx := context.Background()
-	cfg, err := setup.ChainsWithEdgeChallengeManager()
-	require.NoError(t, err)
-	chain := cfg.Chains[0]
-
-	abi, err := rollupgen.RollupCoreMetaData.GetAbi()
-	if err != nil {
-		t.Fatal(err)
-	}
-	abiEvt := abi.Events["AssertionCreated"]
-	evtID := abiEvt.ID
-
-	// The backend is bad and sent logs in the wrong order and also
-	// sent "removed" logs from a nasty reorg.
-	logs := []types.Log{
-		{
-			BlockNumber: 120,
-			Index:       0,
-			Topics: []common.Hash{
-				evtID,
-				common.BigToHash(big.NewInt(1)),
-			},
-		}, {
-			BlockNumber: 119,
-			Index:       0,
-			Topics: []common.Hash{
-				evtID,
-				common.BigToHash(big.NewInt(0)),
-			},
-		}, {
-			BlockNumber: 122,
-			Index:       4,
-			Topics: []common.Hash{
-				evtID,
-				common.BigToHash(big.NewInt(-1)),
-			},
-			Removed: true,
-		},
-		{
-			BlockNumber: 122,
-			Index:       3,
-			Topics: []common.Hash{
-				evtID,
-				common.BigToHash(big.NewInt(3)),
-			},
-		},
-		{
-			BlockNumber: 122,
-			Index:       2,
-			Topics: []common.Hash{
-				evtID,
-				common.BigToHash(big.NewInt(2)),
-			},
-		},
-	}
-
-	chain.SetBackend(&mockBackend{logs: logs})
-
-	latest, err := chain.LatestCreatedAssertionHashes(ctx)
-	require.NoError(t, err)
-
-	// The logs received were in the wrong order, but their IDs indicate their expected position
-	// in the return slice.
-	require.Equal(t, 4, len(latest))
-	for i, id := range latest {
-		require.Equal(t, uint64(i), id.Big().Uint64())
-	}
 }

--- a/chain-abstraction/sol-implementation/assertion_chain_test.go
+++ b/chain-abstraction/sol-implementation/assertion_chain_test.go
@@ -399,10 +399,11 @@ func TestAssertionBySequenceNum(t *testing.T) {
 	chain := cfg.Chains[0]
 	latestConfirmed, err := chain.LatestConfirmed(ctx)
 	require.NoError(t, err)
-	_, err = chain.GetAssertion(ctx, latestConfirmed.Id())
+	opts := &bind.CallOpts{Context: ctx}
+	_, err = chain.GetAssertion(ctx, opts, latestConfirmed.Id())
 	require.NoError(t, err)
 
-	_, err = chain.GetAssertion(ctx, protocol.AssertionHash{Hash: common.BytesToHash([]byte("foo"))})
+	_, err = chain.GetAssertion(ctx, opts, protocol.AssertionHash{Hash: common.BytesToHash([]byte("foo"))})
 	require.ErrorIs(t, err, solimpl.ErrNotFound)
 }
 

--- a/challenge-manager/chain-watcher/watcher.go
+++ b/challenge-manager/chain-watcher/watcher.go
@@ -919,7 +919,7 @@ type filterRange struct {
 // Gets the start and end block numbers for our filter queries, starting from the
 // latest confirmed assertion's block number up to the latest block number.
 func (w *Watcher) getStartEndBlockNum(ctx context.Context) (filterRange, error) {
-	latestConfirmed, err := w.chain.LatestConfirmed(ctx)
+	latestConfirmed, err := w.chain.LatestConfirmed(ctx, w.chain.GetCallOptsWithDesiredRpcHeadBlockNumber(&bind.CallOpts{Context: ctx}))
 	if err != nil {
 		return filterRange{}, err
 	}

--- a/challenge-manager/challenges.go
+++ b/challenge-manager/challenges.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/OffchainLabs/bold/containers/option"
 	l2stateprovider "github.com/OffchainLabs/bold/layer2-state-provider"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/log"
 
 	protocol "github.com/OffchainLabs/bold/chain-abstraction"
@@ -21,7 +22,7 @@ import (
 // and starting a challenge transaction. If the challenge creation is successful, we add a leaf
 // with an associated history commitment to it and spawn a challenge tracker in the background.
 func (m *Manager) ChallengeAssertion(ctx context.Context, id protocol.AssertionHash) (bool, error) {
-	assertion, err := m.chain.GetAssertion(ctx, id)
+	assertion, err := m.chain.GetAssertion(ctx, &bind.CallOpts{Context: ctx}, id)
 	if err != nil {
 		return false, errors.Wrapf(err, "could not get assertion to challenge with id %#x", id)
 	}

--- a/testing/mocks/mocks.go
+++ b/testing/mocks/mocks.go
@@ -6,8 +6,9 @@ package mocks
 
 import (
 	"context"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 
 	protocol "github.com/OffchainLabs/bold/chain-abstraction"
 	"github.com/OffchainLabs/bold/containers/option"
@@ -413,8 +414,8 @@ func (m *MockProtocol) MinAssertionPeriodBlocks(ctx context.Context) (uint64, er
 	return args.Get(0).(uint64), args.Error(1)
 }
 
-func (m *MockProtocol) GetAssertion(ctx context.Context, id protocol.AssertionHash) (protocol.Assertion, error) {
-	args := m.Called(ctx, id)
+func (m *MockProtocol) GetAssertion(ctx context.Context, opts *bind.CallOpts, id protocol.AssertionHash) (protocol.Assertion, error) {
+	args := m.Called(ctx, opts, id)
 	return args.Get(0).(protocol.Assertion), args.Error(1)
 }
 func (m *MockProtocol) AssertionStatus(ctx context.Context, id protocol.AssertionHash) (protocol.AssertionStatus, error) {

--- a/testing/mocks/mocks.go
+++ b/testing/mocks/mocks.go
@@ -443,8 +443,8 @@ func (m *MockProtocol) LatestCreatedAssertion(ctx context.Context) (protocol.Ass
 	return args.Get(0).(protocol.Assertion), args.Error(1)
 }
 
-func (m *MockProtocol) LatestConfirmed(ctx context.Context) (protocol.Assertion, error) {
-	args := m.Called(ctx)
+func (m *MockProtocol) LatestConfirmed(ctx context.Context, opts *bind.CallOpts) (protocol.Assertion, error) {
+	args := m.Called(ctx, opts)
 	return args.Get(0).(protocol.Assertion), args.Error(1)
 }
 


### PR DESCRIPTION
When we post an assertion, we check if it already exists based on the finalized state. However, if it already exists based on the _latest_ block, we will get a bunch of annoying execution reverted `EXPECTED_ASSERTION_SEEN` logs. In fact, if the assertion exists based on latest head, we should be fine here. When we perform the existence check before posting, we should use the `latest` block for this.

This also checks that the latest confirmed assertion is the parent of an assertion we are trying to confirm, by using latest head to get rid of execution reverts.