### PR TITLE
Fix Fast Confirm Assertions Flake

### DIFF
--- a/assertions/BUILD.bazel
+++ b/assertions/BUILD.bazel
@@ -45,6 +45,7 @@ go_test(
         "//challenge-manager",
         "//challenge-manager/types",
         "//containers/threadsafe",
+        "//runtime",
         "//solgen/go/bridgegen",
         "//solgen/go/mocksgen",
         "//solgen/go/rollupgen",


### PR DESCRIPTION
Fixes CI flakiness for assertions/

```
//assertions:assertions_test                                             PASSED in 4.6s
  Stats over 10 runs: max = 4.6s, min = 4.0s, avg = 4.1s, dev = 0.2s

Executed 1 out of 1 test: 1 test passes.
```
had an 80% failure rate before