### PR TITLE
Add Virtual Support for Merkle Inclusion Proofs

### DIFF
--- a/state-commitments/optimized/inclusion_proof.go
+++ b/state-commitments/optimized/inclusion_proof.go
@@ -1,0 +1,82 @@
+package optimized
+
+import (
+	"math"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// computeMerkleProof computes the Merkle proof for a leaf at a given index.
+// It uses the last leaf in hLeaves to pad the tree up to the 'virtual' size if needed.
+func computeMerkleProof(index int, virtual int, hLeaves []common.Hash) []common.Hash {
+	N := len(hLeaves)                                // Number of real leaves
+	hN := hLeaves[N-1]                               // Last leaf used for padding
+	D := int(math.Ceil(math.Log2(float64(virtual)))) // Tree depth
+
+	// Precompute hNHashes
+	hNHashes := precomputeHNHashes(hN, D)
+
+	var proof []common.Hash
+	for level := 0; level < D; level++ {
+		nodeIndex := index >> level
+		siblingHash, exists := computeSiblingHash(nodeIndex, level, N, virtual, hLeaves, hNHashes)
+		if exists {
+			proof = append(proof, siblingHash)
+		}
+	}
+	return proof
+}
+
+// precomputeHNHashes precomputes the hashes formed by combining hN with itself at each level.
+func precomputeHNHashes(hN common.Hash, D int) []common.Hash {
+	hNHashes := make([]common.Hash, D+1)
+	hNHashes[0] = hN
+	for level := 1; level <= D; level++ {
+		data := append(hNHashes[level-1].Bytes(), hNHashes[level-1].Bytes()...)
+		hNHashes[level] = crypto.Keccak256Hash(data)
+	}
+	return hNHashes
+}
+
+// computeSiblingHash computes the hash of a node's sibling at a given index and level.
+func computeSiblingHash(nodeIndex int, level int, N int, virtual int, hLeaves []common.Hash, hNHashes []common.Hash) (common.Hash, bool) {
+	siblingIndex := nodeIndex ^ 1
+	numNodes := (virtual + (1 << level) - 1) / (1 << level) // Equivalent to ceil(virtual / (2 ** level))
+
+	if siblingIndex >= numNodes {
+		// No sibling exists; handle according to your tree's rules
+		return common.Hash{}, false
+	} else if siblingIndex >= paddingStartIndexAtLevel(N, level) {
+		return hNHashes[level], true
+	} else {
+		siblingHash := computeNodeHash(siblingIndex, level, N, hLeaves, hNHashes)
+		return siblingHash, true
+	}
+}
+
+// computeNodeHash recursively computes the hash of a node at a given index and level.
+func computeNodeHash(nodeIndex int, level int, N int, hLeaves []common.Hash, hNHashes []common.Hash) common.Hash {
+	if level == 0 {
+		if nodeIndex >= N {
+			// Node is in padding
+			return hNHashes[0]
+		} else {
+			return hLeaves[nodeIndex]
+		}
+	} else {
+		if nodeIndex >= paddingStartIndexAtLevel(N, level) {
+			return hNHashes[level]
+		} else {
+			leftChild := computeNodeHash(2*nodeIndex, level-1, N, hLeaves, hNHashes)
+			rightChild := computeNodeHash(2*nodeIndex+1, level-1, N, hLeaves, hNHashes)
+			data := append(leftChild.Bytes(), rightChild.Bytes()...)
+			return crypto.Keccak256Hash(data)
+		}
+	}
+}
+
+// paddingStartIndexAtLevel calculates the index at which padding starts at a given tree level.
+func paddingStartIndexAtLevel(N int, level int) int {
+	return N / (1 << level)
+}

--- a/state-commitments/optimized/inclusion_proofs_test.go
+++ b/state-commitments/optimized/inclusion_proofs_test.go
@@ -11,6 +11,11 @@ import (
 
 func TestInclusionProofEquivalence(t *testing.T) {
 	simpleHash := crypto.Keccak256Hash([]byte("foo"))
+	rehashed := crypto.Keccak256Hash(simpleHash.Bytes())
+	left := crypto.Keccak256Hash(rehashed.Bytes(), rehashed.Bytes())
+	right := crypto.Keccak256Hash(rehashed.Bytes(), rehashed.Bytes())
+	total := crypto.Keccak256Hash(left.Bytes(), right.Bytes())
+	_ = total
 	leaves := []common.Hash{
 		simpleHash,
 		simpleHash,

--- a/state-commitments/optimized/inclusion_proofs_test.go
+++ b/state-commitments/optimized/inclusion_proofs_test.go
@@ -1,0 +1,31 @@
+package optimized
+
+import (
+	"testing"
+
+	"github.com/OffchainLabs/bold/state-commitments/history"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInclusionProofEquivalence(t *testing.T) {
+	simpleHash := crypto.Keccak256Hash([]byte("foo"))
+	leaves := []common.Hash{
+		simpleHash,
+		simpleHash,
+		simpleHash,
+		simpleHash,
+	}
+	commit, err := NewCommitment(leaves, 4)
+	require.NoError(t, err)
+	oldLeaves := []common.Hash{
+		simpleHash,
+		simpleHash,
+		simpleHash,
+		simpleHash,
+	}
+	oldCommit, err := history.New(oldLeaves)
+	require.NoError(t, err)
+	require.Equal(t, commit.Merkle, oldCommit.Merkle)
+}

--- a/state-commitments/optimized/inclusion_proofs_test.go
+++ b/state-commitments/optimized/inclusion_proofs_test.go
@@ -11,11 +11,6 @@ import (
 
 func TestInclusionProofEquivalence(t *testing.T) {
 	simpleHash := crypto.Keccak256Hash([]byte("foo"))
-	rehashed := crypto.Keccak256Hash(simpleHash.Bytes())
-	left := crypto.Keccak256Hash(rehashed.Bytes(), rehashed.Bytes())
-	right := crypto.Keccak256Hash(rehashed.Bytes(), rehashed.Bytes())
-	total := crypto.Keccak256Hash(left.Bytes(), right.Bytes())
-	_ = total
 	leaves := []common.Hash{
 		simpleHash,
 		simpleHash,


### PR DESCRIPTION
Follow up to #681 , this PR adds support for virtual, Merkle inclusion proofs for the optimized implementation. Still has a few rough edges, needs more tests, adding more safety conditions, and reducing copying