### PR TITLE
Add test sizes to small test targets.

### DIFF
--- a/api/db/BUILD.bazel
+++ b/api/db/BUILD.bazel
@@ -32,4 +32,5 @@ go_test(
         "@com_github_mattn_go_sqlite3//:go-sqlite3",
         "@com_github_stretchr_testify//require",
     ],
+    size = "small",
 )

--- a/assertions/BUILD.bazel
+++ b/assertions/BUILD.bazel
@@ -57,4 +57,5 @@ go_test(
         "@com_github_ethereum_go_ethereum//common",
         "@com_github_stretchr_testify//require",
     ],
+    size = "small",
 )

--- a/chain-abstraction/sol-implementation/BUILD.bazel
+++ b/chain-abstraction/sol-implementation/BUILD.bazel
@@ -69,4 +69,5 @@ go_test(
         "@com_github_ethereum_go_ethereum//core/types",
         "@com_github_stretchr_testify//require",
     ],
+    size = "small",
 )

--- a/challenge-manager/BUILD.bazel
+++ b/challenge-manager/BUILD.bazel
@@ -56,4 +56,5 @@ go_test(
         "@com_github_ethereum_go_ethereum//common",
         "@com_github_stretchr_testify//require",
     ],
+    size = "small",
 )

--- a/challenge-manager/chain-watcher/BUILD.bazel
+++ b/challenge-manager/chain-watcher/BUILD.bazel
@@ -39,4 +39,5 @@ go_test(
         "@com_github_ethereum_go_ethereum//common",
         "@com_github_stretchr_testify//require",
     ],
+    size = "small",
 )

--- a/challenge-manager/challenge-tree/BUILD.bazel
+++ b/challenge-manager/challenge-tree/BUILD.bazel
@@ -45,4 +45,5 @@ go_test(
         "@com_github_ethereum_go_ethereum//common",
         "@com_github_stretchr_testify//require",
     ],
+    size = "small",
 )

--- a/containers/BUILD.bazel
+++ b/containers/BUILD.bazel
@@ -12,4 +12,5 @@ go_test(
     srcs = ["slice_test.go"],
     embed = [":containers"],
     deps = ["@com_github_stretchr_testify//require"],
+    size = "small",
 )

--- a/containers/events/BUILD.bazel
+++ b/containers/events/BUILD.bazel
@@ -12,4 +12,5 @@ go_test(
     srcs = ["producer_test.go"],
     embed = [":events"],
     deps = ["@com_github_stretchr_testify//require"],
+    size = "small",
 )

--- a/containers/fsm/BUILD.bazel
+++ b/containers/fsm/BUILD.bazel
@@ -13,4 +13,5 @@ go_test(
     srcs = ["fsm_test.go"],
     embed = [":fsm"],
     deps = ["@com_github_stretchr_testify//require"],
+    size = "small",
 )

--- a/containers/threadsafe/BUILD.bazel
+++ b/containers/threadsafe/BUILD.bazel
@@ -28,4 +28,5 @@ go_test(
     ],
     embed = [":threadsafe"],
     deps = ["@com_github_stretchr_testify//require"],
+    size = "small",
 )

--- a/layer2-state-provider/BUILD.bazel
+++ b/layer2-state-provider/BUILD.bazel
@@ -30,4 +30,5 @@ go_test(
         "//containers/option",
         "@com_github_stretchr_testify//require",
     ],
+    size = "small",
 )

--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -12,4 +12,5 @@ go_test(
     srcs = ["math_test.go"],
     embed = [":math"],
     deps = ["@com_github_stretchr_testify//require"],
+    size = "small",
 )

--- a/runtime/BUILD.bazel
+++ b/runtime/BUILD.bazel
@@ -16,4 +16,5 @@ go_test(
     srcs = ["retry_test.go"],
     embed = [":runtime"],
     deps = ["@com_github_stretchr_testify//require"],
+    size = "small",
 )

--- a/state-commitments/history/BUILD.bazel
+++ b/state-commitments/history/BUILD.bazel
@@ -21,4 +21,5 @@ go_test(
         "@com_github_ethereum_go_ethereum//common",
         "@com_github_stretchr_testify//require",
     ],
+    size = "small",
 )

--- a/state-commitments/inclusion-proofs/BUILD.bazel
+++ b/state-commitments/inclusion-proofs/BUILD.bazel
@@ -22,4 +22,5 @@ go_test(
         "@com_github_ethereum_go_ethereum//common",
         "@com_github_stretchr_testify//require",
     ],
+    size = "small",
 )

--- a/state-commitments/prefix-proofs/BUILD.bazel
+++ b/state-commitments/prefix-proofs/BUILD.bazel
@@ -36,4 +36,5 @@ go_test(
         "@com_github_ethereum_go_ethereum//ethclient/simulated",
         "@com_github_stretchr_testify//require",
     ],
+    size = "small",
 )

--- a/testing/mocks/state-provider/BUILD.bazel
+++ b/testing/mocks/state-provider/BUILD.bazel
@@ -39,4 +39,5 @@ go_test(
         "@com_github_ethereum_go_ethereum//crypto",
         "@com_github_stretchr_testify//require",
     ],
+    size = "small",
 )

--- a/time/BUILD.bazel
+++ b/time/BUILD.bazel
@@ -11,4 +11,5 @@ go_test(
     name = "time_test",
     srcs = ["time_reference_test.go"],
     embed = [":time"],
+    size = "small",
 )


### PR DESCRIPTION
This will cause us to deliberately decide if we need to increase the
test size if they get bigger. It also prevents a warning in the
output of `bazel test //...`

Intentionally ignoring the in-progress cache as it is going away
in #689
