### PR TITLE
Update the github actions for CI

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: "stable"
       - id: list
-        uses: shogo82148/actions-go-fuzz/list@v0
+        uses: shogo82148/actions-go-fuzz/list@v1
     outputs:
       fuzz-tests: ${{steps.list.outputs.fuzz-tests}}
 
@@ -31,11 +31,11 @@ jobs:
       matrix:
         include: ${{fromJson(needs.list.outputs.fuzz-tests)}}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: "stable"
-      - uses: shogo82148/actions-go-fuzz/run@v0
+      - uses: shogo82148/actions-go-fuzz/run@v1
         with:
           packages: ${{ matrix.package }}
           fuzz-regexp: ${{ matrix.func }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Go mod tidy checker
         id: gomodtidy
@@ -25,43 +25,41 @@ jobs:
       GO111MODULE: on
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v3
+        uses: actions/checkout@v4
+      - name: Set up Go 1.21
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: 1.21.x
       - name: Run Gosec Security Scanner
         run: | # https://github.com/securego/gosec/issues/469
           export PATH=$PATH:$(go env GOPATH)/bin
-          go install github.com/securego/gosec/v2/cmd/gosec@v2.12.0
-          gosec -exclude=G307 ./...
+          go install github.com/securego/gosec/v2/cmd/gosec@v2.21.4
+          gosec -exclude=G307,G115 ./...
 
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v4
+      - name: Set up Go 1.21
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.20.x
-          id: go
+          go-version: 1.21.x
 
       - name: Golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           version: latest
           args: --timeout=10m
-          skip-pkg-cache: true
 
   build:
     name: Build and Test
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -78,10 +76,10 @@ jobs:
       - name: Build solidity contracts
         run: yarn --cwd contracts build
 
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v4
+      - name: Set up Go 1.21
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
         id: go
 
       - name: Install Foundry
@@ -106,7 +104,7 @@ jobs:
         run: ANVIL=$(which anvil) go test -v -covermode=atomic -coverprofile=coverage.out -timeout=20m ./...
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -114,11 +112,11 @@ jobs:
     name: Bazel
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
-      - uses: bazelbuild/setup-bazelisk@v2
+      - uses: bazelbuild/setup-bazelisk@v3
       - name: Mount bazel cache
         uses: actions/cache@v3
         with:
@@ -139,6 +137,6 @@ jobs:
         run: bazel coverage --combined_report=lcov //...
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This also updates the version of go to the 1.21 series because the code on one of the branches is using max which was introduced in 1.21.