### PR TITLE
Update the LICENSE and Copyright info

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -10,27 +10,28 @@ Parameters
 Licensor:             Offchain Labs
 
 Licensed Work:        Arbitrum Nitro
-                      The Licensed Work is (c) 2021-2023 Offchain Labs
+                      The Licensed Work is (c) 2021-2024 Offchain Labs
 
 Additional Use Grant: You may use the Licensed Work in a production environment solely
                       to provide a point of interface to permit end users or applications
                       utilizing the Covered Arbitrum Chains to interact and query the
                       state of a Covered Arbitrum Chain, including without limitation
-                      validating the correctness of the posted chain state. For purposes
-                      of this Additional Use Grant, the "Covered Arbitrum Chains" are
-                      means (a) Arbitrum One (chainid:42161), Arbitrum Nova (chainid:42170),
-                      Arbitrum Rinkeby testnet/Rinkarby (chainid:421611), and
-                      Arbitrum Nitro Goerli testnet (chainid:421613) (b) any future
-                      blockchains authorized to be designated as Covered Arbitrum Chains
-                      by the decentralized autonomous organization governing the Arbitrum
-                      network; and (c) any “Layer 3” Arbitrum-based blockchain that is built
-                      on and settles to another Covered Arbitrum Chain.
+                      validating the correctness of the posted chain state, or to deploy
+                      and operate (x) a blockchain that settles to a Covered Arbitrum Chain
+                      or (y) a blockchain in accordance with, and subject to, the [Arbitrum
+                      Expansion Program Term of Use](https://docs.arbitrum.foundation/assets/files/Arbitrum%20Expansion%20Program%20Jan182024-4f08b0c2cb476a55dc153380fa3e64b0.pdf). For purposes of this
+                      Additional Use Grant, the "Covered Arbitrum Chains" are 
+                      (a) Arbitrum One (chainid:42161), Arbitrum Nova (chainid:42170), 
+                      Arbitrum Rinkeby testnet/Rinkarby (chainid:421611),Arbitrum Nitro
+                      Goerli testnet (chainid:421613), and Arbitrum Sepolia Testnet
+                      (chainid:421614); (b) any future blockchains authorized to be
+                      designated as Covered Arbitrum Chains by the decentralized autonomous
+                      organization governing the Arbitrum network; and (c) any “Layer 3”
+                      Arbitrum-based blockchain that is built on and settles to another
+                      Covered Arbitrum Chain.
 
 
-
-
-
-Change Date:          Dec 31, 2027
+Change Date:          Dec 31, 2028
 
 Change License:       Apache License Version 2.0
 

--- a/api/backend/backend.go
+++ b/api/backend/backend.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 // Package backend handles the business logic for API data fetching
 // for BOLD challenge information. It is meant to be fairly abstract and
 // well-tested.

--- a/api/db/db.go
+++ b/api/db/db.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 // Package db handles the interface to an underlying database of BOLD data
 // for easy querying of information used by the BOLD API.
 package db

--- a/api/db/db_test.go
+++ b/api/db/db_test.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package db
 
 import (

--- a/api/db/schema.go
+++ b/api/db/schema.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package db
 
 var (

--- a/api/server/methods.go
+++ b/api/server/methods.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package server
 
 import (

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 // Package server defines the client-facing API methods for fetching data
 // related to BOLD challenges. It handles HTTP methods with their requests and responses.
 package server

--- a/api/types.go
+++ b/api/types.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package api
 
 import (

--- a/assertions/confirmation.go
+++ b/assertions/confirmation.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package assertions
 
 import (

--- a/assertions/manager.go
+++ b/assertions/manager.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 // Package assertions contains testing utilities for posting and scanning for
 // assertions on chain, which are useful for simulating the responsibilities of

--- a/assertions/manager_test.go
+++ b/assertions/manager_test.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package assertions_test
 

--- a/assertions/poster.go
+++ b/assertions/poster.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package assertions
 

--- a/assertions/poster_test.go
+++ b/assertions/poster_test.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package assertions_test
 

--- a/assertions/sync.go
+++ b/assertions/sync.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package assertions
 
 import (

--- a/assertions/sync_test.go
+++ b/assertions/sync_test.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package assertions
 
 import (

--- a/chain-abstraction/execution_state.go
+++ b/chain-abstraction/execution_state.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 // Package protocol a series of interfaces for interacting with Arbitrum chains' rollup
 // and challenge contracts via a developer-friendly, high-level API.
 package protocol

--- a/chain-abstraction/interfaces.go
+++ b/chain-abstraction/interfaces.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package protocol
 

--- a/chain-abstraction/sol-implementation/assertion_chain.go
+++ b/chain-abstraction/sol-implementation/assertion_chain.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 // Package solimpl includes an easy-to-use abstraction
 // around the challenge protocol contracts using their Go

--- a/chain-abstraction/sol-implementation/assertion_chain_helper_test.go
+++ b/chain-abstraction/sol-implementation/assertion_chain_helper_test.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package solimpl
 
 import protocol "github.com/offchainlabs/bold/chain-abstraction"

--- a/chain-abstraction/sol-implementation/assertion_chain_test.go
+++ b/chain-abstraction/sol-implementation/assertion_chain_test.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package solimpl_test
 

--- a/chain-abstraction/sol-implementation/edge_challenge_manager.go
+++ b/chain-abstraction/sol-implementation/edge_challenge_manager.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package solimpl
 

--- a/chain-abstraction/sol-implementation/edge_challenge_manager_test.go
+++ b/chain-abstraction/sol-implementation/edge_challenge_manager_test.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package solimpl_test
 

--- a/chain-abstraction/sol-implementation/fifo_lock.go
+++ b/chain-abstraction/sol-implementation/fifo_lock.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package solimpl
 
 import (

--- a/chain-abstraction/sol-implementation/fifo_lock_test.go
+++ b/chain-abstraction/sol-implementation/fifo_lock_test.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package solimpl
 
 import (

--- a/chain-abstraction/sol-implementation/metrics_contract_backend.go
+++ b/chain-abstraction/sol-implementation/metrics_contract_backend.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package solimpl
 

--- a/chain-abstraction/sol-implementation/tracked_contract_backend.go
+++ b/chain-abstraction/sol-implementation/tracked_contract_backend.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package solimpl
 

--- a/chain-abstraction/sol-implementation/tracked_contract_backend_test.go
+++ b/chain-abstraction/sol-implementation/tracked_contract_backend_test.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package solimpl
 
 import (

--- a/chain-abstraction/sol-implementation/transact.go
+++ b/chain-abstraction/sol-implementation/transact.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package solimpl
 

--- a/chain-abstraction/sol-implementation/types.go
+++ b/chain-abstraction/sol-implementation/types.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package solimpl
 

--- a/chain-abstraction/sol-implementation/types_test.go
+++ b/chain-abstraction/sol-implementation/types_test.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package solimpl
 
 import protocol "github.com/offchainlabs/bold/chain-abstraction"

--- a/challenge-manager/chain-watcher/watcher.go
+++ b/challenge-manager/chain-watcher/watcher.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 // Package watcher implements the main monitoring logic for protocol validators.
 // The challenge watcher is a singleton service available to all spawned edge

--- a/challenge-manager/chain-watcher/watcher_test.go
+++ b/challenge-manager/chain-watcher/watcher_test.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package watcher
 

--- a/challenge-manager/challenge-tree/add_edge.go
+++ b/challenge-manager/challenge-tree/add_edge.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package challengetree
 
 import (

--- a/challenge-manager/challenge-tree/ancestors.go
+++ b/challenge-manager/challenge-tree/ancestors.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package challengetree
 
 import (

--- a/challenge-manager/challenge-tree/ancestors_test.go
+++ b/challenge-manager/challenge-tree/ancestors_test.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package challengetree
 

--- a/challenge-manager/challenge-tree/compute_ancestors_test.go
+++ b/challenge-manager/challenge-tree/compute_ancestors_test.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package challengetree
 

--- a/challenge-manager/challenge-tree/inherited_timer.go
+++ b/challenge-manager/challenge-tree/inherited_timer.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package challengetree
 
 import (

--- a/challenge-manager/challenge-tree/inherited_timer_test.go
+++ b/challenge-manager/challenge-tree/inherited_timer_test.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package challengetree
 
 import (

--- a/challenge-manager/challenge-tree/local_timer.go
+++ b/challenge-manager/challenge-tree/local_timer.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package challengetree
 

--- a/challenge-manager/challenge-tree/local_timer_test.go
+++ b/challenge-manager/challenge-tree/local_timer_test.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package challengetree
 

--- a/challenge-manager/challenge-tree/mock/edge.go
+++ b/challenge-manager/challenge-tree/mock/edge.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 // Package mock includes specific mock setups for edge types used in internal tests.
 package mock
 

--- a/challenge-manager/challenge-tree/paths.go
+++ b/challenge-manager/challenge-tree/paths.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package challengetree
 
 import (

--- a/challenge-manager/challenge-tree/paths_test.go
+++ b/challenge-manager/challenge-tree/paths_test.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package challengetree
 
 import (

--- a/challenge-manager/challenge-tree/tree.go
+++ b/challenge-manager/challenge-tree/tree.go
@@ -1,9 +1,10 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 // Package challengetree includes logic for keeping track of royal edges within a challenge
 // with utilities for computing cumulative path timers for said edges. This is helpful during
 // the confirmation process needed by edge trackers.
-//
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
 package challengetree
 
 import (

--- a/challenge-manager/challenge-tree/tree_test.go
+++ b/challenge-manager/challenge-tree/tree_test.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package challengetree
 

--- a/challenge-manager/challenges.go
+++ b/challenge-manager/challenges.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package challengemanager
 

--- a/challenge-manager/edge-tracker/challenge_confirmation.go
+++ b/challenge-manager/edge-tracker/challenge_confirmation.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package edgetracker
 
 import (

--- a/challenge-manager/edge-tracker/fsm_states.go
+++ b/challenge-manager/edge-tracker/fsm_states.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package edgetracker
 

--- a/challenge-manager/edge-tracker/tracker.go
+++ b/challenge-manager/edge-tracker/tracker.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 // Package edgetracker contains the logic for tracking an edge in the challenge manager. It keeps
 // track of edges created and their own state transitions until an eventual confirmation.

--- a/challenge-manager/edge-tracker/transition_table.go
+++ b/challenge-manager/edge-tracker/transition_table.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package edgetracker
 

--- a/challenge-manager/manager.go
+++ b/challenge-manager/manager.go
@@ -1,8 +1,9 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 // Package challengemanager includes the main entrypoint for setting up a BoLD
 // challenge manager instance and challenging assertions onchain.
-//
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
 package challengemanager
 
 import (

--- a/challenge-manager/manager_test.go
+++ b/challenge-manager/manager_test.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package challengemanager
 

--- a/challenge-manager/stack.go
+++ b/challenge-manager/stack.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package challengemanager
 
 import (

--- a/challenge-manager/types/interfaces.go
+++ b/challenge-manager/types/interfaces.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 // Package types includes types and interfaces specific to the challenge manager instance.
 package types
 

--- a/challenge-manager/types/mode.go
+++ b/challenge-manager/types/mode.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package types
 
 type Mode uint8

--- a/containers/events/producer.go
+++ b/containers/events/producer.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package events
 
 import (

--- a/containers/events/producer_test.go
+++ b/containers/events/producer_test.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package events
 
 import (

--- a/containers/fsm/fsm.go
+++ b/containers/fsm/fsm.go
@@ -1,9 +1,10 @@
-// Package fsm defines a generic, finite state machine in Go that is extremely simple
-// and type-safe. It is used by edge tracker goroutines to keep track of the edge states
-// and transition to confirmation.
-//
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
+// Package fsm defines a generic, finite state machine in Go that is extremely
+// simple and type-safe. It is used by edge tracker goroutines to keep track of
+// the edge states and transition to confirmation.
 package fsm
 
 import (

--- a/containers/fsm/fsm_test.go
+++ b/containers/fsm/fsm_test.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package fsm
 

--- a/containers/option/option_type.go
+++ b/containers/option/option_type.go
@@ -1,9 +1,10 @@
-// Package option defines a generic option type as a way of representing "nothingness"
-// or "something" in a type-safe way. This is useful for representing optional values
-// without the need for nil checks or pointers.
-//
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
+// Package option defines a generic option type as a way of representing
+// "nothingness" or "something" in a type-safe way. This is useful for
+// representing optional values without the need for nil checks or pointers.
 package option
 
 type Option[T any] struct {

--- a/containers/slice.go
+++ b/containers/slice.go
@@ -1,7 +1,9 @@
-// Package containers defines generic data structures to be used in the BOLD repository.
-//
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
+// Package containers defines generic data structures to be used in the BoLD
+// repository.
 package containers
 
 import "fmt"

--- a/containers/slice_test.go
+++ b/containers/slice_test.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package containers
 

--- a/containers/threadsafe/collections_test.go
+++ b/containers/threadsafe/collections_test.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package threadsafe
 

--- a/containers/threadsafe/lru_map.go
+++ b/containers/threadsafe/lru_map.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package threadsafe
 

--- a/containers/threadsafe/lru_set.go
+++ b/containers/threadsafe/lru_set.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package threadsafe
 

--- a/containers/threadsafe/map.go
+++ b/containers/threadsafe/map.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package threadsafe
 

--- a/containers/threadsafe/map_test.go
+++ b/containers/threadsafe/map_test.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package threadsafe
 
 import (

--- a/containers/threadsafe/set.go
+++ b/containers/threadsafe/set.go
@@ -1,9 +1,7 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
-// Package threadsafe includes generic utilities for maps and sets that can
-// be safely used concurrently for type-safety at compile time with the
-// bare minimum methods needed in this repository.
 package threadsafe
 
 import (

--- a/containers/threadsafe/set_test.go
+++ b/containers/threadsafe/set_test.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package threadsafe
 
 import (

--- a/containers/threadsafe/slice.go
+++ b/containers/threadsafe/slice.go
@@ -1,8 +1,9 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 // Package threadsafe defines generic, threadsafe analogues of common data structures
-// in Go such as maps, slices, and sets for use in BOLD with an intuitive API.
-//
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// in Go such as maps, slices, and sets for use in BoLD with an intuitive API.
 package threadsafe
 
 import (

--- a/containers/threadsafe/slice_test.go
+++ b/containers/threadsafe/slice_test.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package threadsafe
 
 import (

--- a/layer2-state-provider/history_commitment_provider.go
+++ b/layer2-state-provider/history_commitment_provider.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package l2stateprovider
 
 import (

--- a/layer2-state-provider/history_commitment_provider_test.go
+++ b/layer2-state-provider/history_commitment_provider_test.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package l2stateprovider
 
 import (

--- a/layer2-state-provider/provider.go
+++ b/layer2-state-provider/provider.go
@@ -1,9 +1,10 @@
-// Package l2stateprovider defines a dependency which provides L2 states and proofs
-// needed for the challenge manager to interact with Arbitrum chains' rollup and challenge
-// contracts.
-//
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
+// Package l2stateprovider defines a dependency which provides L2 states and
+// proofs needed for the challenge manager to interact with an Arbitrum chain's
+// rollup and challenge contracts.
 package l2stateprovider
 
 import (

--- a/logs/ephemeral/log.go
+++ b/logs/ephemeral/log.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package ephemeral
 
 import (

--- a/logs/ephemeral/log_test.go
+++ b/logs/ephemeral/log_test.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package ephemeral
 
 import (

--- a/math/intlog2.go
+++ b/math/intlog2.go
@@ -1,3 +1,7 @@
+// Copyright 2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package math
 
 import "math/bits"

--- a/math/intlog2_test.go
+++ b/math/intlog2_test.go
@@ -1,5 +1,6 @@
 // Copyright 2024, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package math
 

--- a/math/math.go
+++ b/math/math.go
@@ -1,8 +1,9 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 // Package math defines utilities for performing operations critical to the
 // computations performed during a challenge in BOLD.
-//
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
 package math
 
 import (

--- a/math/math_test.go
+++ b/math/math_test.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package math
 

--- a/runtime/retry.go
+++ b/runtime/retry.go
@@ -1,9 +1,10 @@
-// Package runtime defines utilities that deal with managing lifecycles of functions
-// and important behaviors at the application runtime, such as retrying errored
-// functions until they succeed.
-//
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
+// Package runtime defines utilities that deal with managing lifecycles of
+// functions and important behaviors at the application runtime, such as
+// retrying errored functions until they succeed.
 package retry
 
 import (

--- a/runtime/retry_test.go
+++ b/runtime/retry_test.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package retry
 

--- a/solgen/main.go
+++ b/solgen/main.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package main
 

--- a/state-commitments/history/history_commitment.go
+++ b/state-commitments/history/history_commitment.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 // Package history provides functions for computing merkle tree roots
 // and proofs needed for the BoLD protocol's history commitments.
 //

--- a/state-commitments/history/history_commitment_test.go
+++ b/state-commitments/history/history_commitment_test.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package history
 
 import (

--- a/state-commitments/inclusion-proofs/inclusion_proofs.go
+++ b/state-commitments/inclusion-proofs/inclusion_proofs.go
@@ -1,8 +1,9 @@
-// Package inclusionproofs defines a series of utilities for generating and verifying
-// traditional Merkle proofs of data.
-//
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
+// Package inclusionproofs defines a series of utilities for generating and
+// verifying traditional Merkle proofs of data.
 package inclusionproofs
 
 import (

--- a/state-commitments/inclusion-proofs/inclusion_proofs_test.go
+++ b/state-commitments/inclusion-proofs/inclusion_proofs_test.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package inclusionproofs
 

--- a/state-commitments/legacy/legacy.go
+++ b/state-commitments/legacy/legacy.go
@@ -1,8 +1,9 @@
-// Package history defines the primitive HistoryCommitment type in the BOLD
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
+// Package history defines the primitive HistoryCommitment type in the BoLD
 // protocol.
-//
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
 package legacy
 
 import (

--- a/state-commitments/legacy/legacy_test.go
+++ b/state-commitments/legacy/legacy_test.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package legacy
 

--- a/state-commitments/prefix-proofs/merkle_expansions.go
+++ b/state-commitments/prefix-proofs/merkle_expansions.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package prefixproofs
 

--- a/state-commitments/prefix-proofs/merkle_expansions_test.go
+++ b/state-commitments/prefix-proofs/merkle_expansions_test.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package prefixproofs
 

--- a/state-commitments/prefix-proofs/prefix_proofs.go
+++ b/state-commitments/prefix-proofs/prefix_proofs.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 // Package prefixproofs defines utilities for creating Merkle prefix proofs for binary
 // trees. It is used extensively in the challenge protocol for making challenge moves on-chain.

--- a/state-commitments/prefix-proofs/prefix_proofs_test.go
+++ b/state-commitments/prefix-proofs/prefix_proofs_test.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package prefixproofs_test
 

--- a/testing/casttest/safe.go
+++ b/testing/casttest/safe.go
@@ -1,5 +1,5 @@
 // Copyright 2024, Offchain Labs, Inc.
-// For license information, see
+// For license information, see:
 // https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 // Package casttest exposes test helper functions to wrap safecast calls.

--- a/testing/endtoend/backend/anvil_local.go
+++ b/testing/endtoend/backend/anvil_local.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package backend
 

--- a/testing/endtoend/backend/anvil_local_test.go
+++ b/testing/endtoend/backend/anvil_local_test.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package backend
 

--- a/testing/endtoend/backend/anvil_priv_keys.go
+++ b/testing/endtoend/backend/anvil_priv_keys.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package backend
 
 // From: https://github.com/foundry-rs/foundry/tree/master/crates/anvil

--- a/testing/endtoend/backend/backend.go
+++ b/testing/endtoend/backend/backend.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package backend
 

--- a/testing/endtoend/backend/simulated.go
+++ b/testing/endtoend/backend/simulated.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package backend
 
 import (

--- a/testing/endtoend/e2e_test.go
+++ b/testing/endtoend/e2e_test.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package endtoend
 
 import (

--- a/testing/endtoend/expectations.go
+++ b/testing/endtoend/expectations.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package endtoend
 
 import (

--- a/testing/endtoend/helpers_test.go
+++ b/testing/endtoend/helpers_test.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package endtoend
 
 import (

--- a/testing/integration/prefixproofs_test.go
+++ b/testing/integration/prefixproofs_test.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package prefixproofs
 
 import (

--- a/testing/mocks/mocks.go
+++ b/testing/mocks/mocks.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 // Package mocks includes simple mocks for unit testing BOLD.
 // nolint:errcheck

--- a/testing/mocks/state-provider/execution_engine.go
+++ b/testing/mocks/state-provider/execution_engine.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 package stateprovider
 
 import (

--- a/testing/mocks/state-provider/execution_engine_test.go
+++ b/testing/mocks/state-provider/execution_engine_test.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 package stateprovider
 
 import (

--- a/testing/mocks/state-provider/history_provider.go
+++ b/testing/mocks/state-provider/history_provider.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package stateprovider
 
 import (

--- a/testing/mocks/state-provider/history_provider_test.go
+++ b/testing/mocks/state-provider/history_provider_test.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package stateprovider
 
 import (

--- a/testing/mocks/state-provider/layer2_state_provider.go
+++ b/testing/mocks/state-provider/layer2_state_provider.go
@@ -1,8 +1,9 @@
-// Package stateprovider defines smarter mocks for testing purposes that can simulate a layer 2
-// state provider and and layer 2 state execution.
-//
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
+// Package stateprovider defines smarter mocks for testing purposes that can
+// simulate a layer 2 state provider and and layer 2 state execution.
 package stateprovider
 
 import (

--- a/testing/mocks/state-provider/layer2_state_provider_test.go
+++ b/testing/mocks/state-provider/layer2_state_provider_test.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 package stateprovider
 
 import (

--- a/testing/rollup_config.go
+++ b/testing/rollup_config.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 
 package challenge_testing
 

--- a/testing/setup/rollup_stack.go
+++ b/testing/setup/rollup_stack.go
@@ -1,7 +1,8 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 // Package setup prepares a simulated backend for testing.
-//
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
 package setup
 
 import (

--- a/testing/setup/simulated_backend_wrapper.go
+++ b/testing/setup/simulated_backend_wrapper.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
 package setup
 
 import (

--- a/testing/tx.go
+++ b/testing/tx.go
@@ -1,7 +1,8 @@
-// Package challenge_testing includes all non-production code used in BOLD.
-//
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
+// Package challenge_testing includes all non-production code used in BoLD.
 package challenge_testing
 
 import (

--- a/time/time_reference.go
+++ b/time/time_reference.go
@@ -1,7 +1,8 @@
-// Package time defines abstractions for time-related operations in BOLD.
-//
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
+
+// Package time defines abstractions for time-related operations in BoLD.
 package time
 
 import (

--- a/time/time_reference_test.go
+++ b/time/time_reference_test.go
@@ -1,5 +1,6 @@
-// Copyright 2023, Offchain Labs, Inc.
-// For license information, see https://github.com/offchainlabs/bold/blob/main/LICENSE
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/offchainlabs/bold/blob/main/LICENSE.md
 package time
 
 import (


### PR DESCRIPTION
This commit does the following 5 things:
  1. Replace LICENSE with LICENSE.md from the nitro repo.
	2. Add a Copyright notice to any non-generated go file missing one.
	3. Update the Copyright range to include 2024.
	4. Update the references to LICENSE to point to LICENSE.md.
	5. Move all of the Copyright notices to the first line of the file.

NOTE: The 5th item is done because it is standard among go packages NOT to include the copyright notice in the godoc for packages. This can be seen in the implementation of the go standard libraries and comparing the hit-rate of the following to github-wide code searches:
https://tinyurl.com/9pxcdrdc
https://tinyurl.com/mvwexv6d