### PR TITLE
Fix the e2e_test on main

### DIFF
--- a/challenge-manager/BUILD.bazel
+++ b/challenge-manager/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
         "//runtime",
         "//time",
         "//util/stopwaiter",
-        "@com_github_ccoveille_go_safecast//:go-safecast",
         "@com_github_ethereum_go_ethereum//accounts/abi/bind",
         "@com_github_ethereum_go_ethereum//common",
         "@com_github_ethereum_go_ethereum//core/types",

--- a/challenge-manager/challenge-tree/paths.go
+++ b/challenge-manager/challenge-tree/paths.go
@@ -9,6 +9,7 @@ import (
 	"container/list"
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/pkg/errors"
 
@@ -202,12 +203,12 @@ func (ht *RoyalChallengeTree) findEssentialPaths(
 			if err != nil {
 				return nil, nil, err
 			}
-			lowerPath := path
-			upperPath := path
+			lowerPath := slices.Clone(path)
+			upperPath := slices.Clone(path)
 			lowerPath = append(lowerPath, lowerChildId)
 			upperPath = append(upperPath, upperChildId)
-			lowerTimers := currentTimers
-			upperTimers := currentTimers
+			lowerTimers := slices.Clone(currentTimers)
+			upperTimers := slices.Clone(currentTimers)
 			lowerTimers = append(lowerTimers, lowerTimer)
 			upperTimers = append(upperTimers, upperTimer)
 			stack.push(&visited{
@@ -228,9 +229,9 @@ func (ht *RoyalChallengeTree) findEssentialPaths(
 			if err != nil {
 				return nil, nil, err
 			}
-			claimingPath := path
+			claimingPath := slices.Clone(path)
 			claimingPath = append(claimingPath, claimingEdge.Id())
-			claimingTimers := currentTimers
+			claimingTimers := slices.Clone(currentTimers)
 			claimingTimers = append(claimingTimers, claimingEdgeTimer)
 			stack.push(&visited{
 				essentialNode: claimingEdge,


### PR DESCRIPTION
Unfortunately, the linter led Pepper to make the problem it was pointing out worse rather than better, and CI didn't run the e2e_test, so we didn't notice it before merging.

FYI, the modification to the BUILD.bazel file is unrelated, and was automatically made with `bazel run //:gazelle`.