### PR TITLE
Allow a HeaderProvider to be passed to the stack

### DIFF
--- a/challenge-manager/manager.go
+++ b/challenge-manager/manager.go
@@ -48,6 +48,11 @@ type AssertionManager interface {
 	SetRivalHandler(types.RivalHandler)
 }
 
+// HeaderProvider is a producer of new block headers.
+type HeaderProvider interface {
+	Subscribe(requireBlockNrUpdates bool) (<-chan *gethtypes.Header, func())
+}
+
 // Manager defines an offchain, challenge manager, which will be
 // an active participant in interacting with the on-chain contracts.
 type Manager struct {
@@ -57,6 +62,7 @@ type Manager struct {
 	watcher                      *watcher.Watcher
 	stateManager                 l2stateprovider.Provider
 	name                         string
+	headerProvider               HeaderProvider
 	timeRef                      utilTime.Reference
 	trackedEdgeIds               *threadsafe.Map[protocol.EdgeId, *edgetracker.Tracker]
 	assertionMetadataCache       *threadsafe.LruMap[protocol.AssertionHash, l2stateprovider.AssociatedAssertionMetadata]
@@ -64,7 +70,6 @@ type Manager struct {
 	notifyOnNumberOfBlocks       uint64
 	mode                         types.Mode
 	claimedAssertionsInChallenge *threadsafe.LruSet[protocol.AssertionHash]
-	headBlockSubscriptions       bool
 	// API
 	api *server.Server
 }
@@ -92,16 +97,17 @@ func WithMode(m types.Mode) Opt {
 	}
 }
 
-// WithAPIServer(*server.Server) sets the API server for the challenge manager.
+// WithAPIServer sets the API server for the challenge manager.
 func WithAPIServer(api *server.Server) Opt {
 	return func(val *Manager) {
 		val.api = api
 	}
 }
 
-func WithHeadBlockSubscriptions() Opt {
+// WithHeaderProvider sets the header provider for the challenge manager.
+func WithHeaderProvider(provider HeaderProvider) Opt {
 	return func(val *Manager) {
-		val.headBlockSubscriptions = true
+		val.headerProvider = provider
 	}
 }
 
@@ -124,7 +130,6 @@ func New(
 		assertionMetadataCache:       threadsafe.NewLruMap(1500, threadsafe.LruMapWithMetric[protocol.AssertionHash, l2stateprovider.AssociatedAssertionMetadata]("batchIndexForAssertionCache")),
 		notifyOnNumberOfBlocks:       1,
 		newBlockNotifier:             events.NewProducer[*gethtypes.Header](),
-		headBlockSubscriptions:       false,
 		claimedAssertionsInChallenge: threadsafe.NewLruSet(1500, threadsafe.LruSetWithMetric[protocol.AssertionHash]("claimedAssertionsInChallenge")),
 		api:                          nil,
 	}
@@ -317,7 +322,7 @@ func (m *Manager) listenForBlockEvents(ctx context.Context) {
 
 	// Then, once the watcher has reached the latest head, we
 	// fire off a block notifications events normally.
-	if m.headBlockSubscriptions {
+	if m.headerProvider != nil {
 		m.tickOnHeadBlockSubscriptions(ctx)
 	} else {
 		m.tickAtInterval(ctx)
@@ -325,12 +330,9 @@ func (m *Manager) listenForBlockEvents(ctx context.Context) {
 }
 
 func (m *Manager) tickOnHeadBlockSubscriptions(ctx context.Context) {
-	ch := make(chan *gethtypes.Header, 100)
-	sub, err := m.chain.Backend().SubscribeNewHead(ctx, ch)
-	if err != nil {
-		panic(err)
-	}
-	defer sub.Unsubscribe()
+	doesNotNeedEveryBlockNumberUpdate := false
+	ch, unsub := m.headerProvider.Subscribe(doesNotNeedEveryBlockNumberUpdate)
+	defer unsub()
 	numBlocksReceived := uint64(0)
 	for {
 		select {
@@ -343,7 +345,6 @@ func (m *Manager) tickOnHeadBlockSubscriptions(ctx context.Context) {
 			if numBlocksReceived%m.notifyOnNumberOfBlocks == 0 {
 				m.newBlockNotifier.Broadcast(ctx, header)
 			}
-		case <-sub.Err():
 		case <-ctx.Done():
 			return
 		}

--- a/testing/endtoend/BUILD.bazel
+++ b/testing/endtoend/BUILD.bazel
@@ -47,15 +47,21 @@ go_test(
 go_library(
     name = "endtoend",
     testonly = 1,
-    srcs = ["expectations.go"],
+    srcs = [
+        "expectations.go",
+        "headers.go",
+    ],
     importpath = "github.com/offchainlabs/bold/testing/endtoend",
     visibility = ["//visibility:public"],
     deps = [
         "//chain-abstraction:protocol",
         "//runtime",
         "//solgen/go/rollupgen",
+        "//testing/endtoend/backend",
         "//testing/setup:setup_lib",
+        "//util/stopwaiter",
         "@com_github_ethereum_go_ethereum//accounts/abi/bind",
+        "@com_github_ethereum_go_ethereum//core/types",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/testing/endtoend/e2e_test.go
+++ b/testing/endtoend/e2e_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
 
 	protocol "github.com/offchainlabs/bold/chain-abstraction"
 	cm "github.com/offchainlabs/bold/challenge-manager"
@@ -271,13 +272,16 @@ func runEndToEndTest(t *testing.T, cfg *e2eConfig) {
 	honestStateManager, err := statemanager.NewForSimpleMachine(t, baseStateManagerOpts...)
 	require.NoError(t, err)
 
+	shp := &simpleHeaderProvider{b: bk, chs: make([]chan<- *gethtypes.Header, 0)}
+	shp.Start(ctx)
+
 	baseStackOpts := []cm.StackOpt{
 		cm.StackWithMode(types.MakeMode),
 		cm.StackWithPollingInterval(cfg.timings.assertionScanningInterval),
 		cm.StackWithPostingInterval(cfg.timings.assertionPostingInterval),
 		cm.StackWithAverageBlockCreationTime(cfg.timings.blockTime),
 		cm.StackWithConfirmationInterval(cfg.timings.assertionConfirmationAttemptInterval),
-		cm.StackWithHeadBlockSubscriptionsEnabled(),
+		cm.StackWithHeaderProvider(shp),
 	}
 
 	name := "honest"


### PR DESCRIPTION
The desire is to be able to be responsive to new blocks as they are created on the parent chain. There was some concern about relying on websockets for this feed of headers, but nitro already has an inprocess abstraction which provides a stream of parent-chain block headers.

The nitro codebase already has an implementation of the HeaderProvider interface that can be passed into the challenge stack, and a tivial one has been added for the end2end testing. Perhaps, after we merge the repos, we can just use the real implementation from the nitro codebase in the e2e_test.go

Part of NIT-2793