### PR TITLE
Base the size of caches on chain configuration

### DIFF
--- a/assertions/poster.go
+++ b/assertions/poster.go
@@ -212,10 +212,7 @@ func (m *Manager) waitToPostIfNeeded(
 	if parentCreationInfo.CreationBlock < latestBlockNumber {
 		blocksSinceLast = latestBlockNumber - parentCreationInfo.CreationBlock
 	}
-	minPeriodBlocks, err := m.chain.MinAssertionPeriodBlocks(ctx)
-	if err != nil {
-		return err
-	}
+	minPeriodBlocks := m.chain.MinAssertionPeriodBlocks()
 	canPostNow := blocksSinceLast >= minPeriodBlocks
 
 	// If we cannot post just yet, we can wait.

--- a/chain-abstraction/interfaces.go
+++ b/chain-abstraction/interfaces.go
@@ -158,7 +158,7 @@ type AssertionChain interface {
 	) (*AssertionCreatedInfo, error)
 	GetCallOptsWithDesiredRpcHeadBlockNumber(opts *bind.CallOpts) *bind.CallOpts
 
-	MinAssertionPeriodBlocks(ctx context.Context) (uint64, error)
+	MinAssertionPeriodBlocks() uint64
 	AssertionUnrivaledBlocks(ctx context.Context, assertionHash AssertionHash) (uint64, error)
 	TopLevelAssertion(ctx context.Context, edgeId EdgeId) (AssertionHash, error)
 	TopLevelClaimHeights(ctx context.Context, edgeId EdgeId) (OriginHeights, error)
@@ -190,6 +190,10 @@ type AssertionChain interface {
 
 	// Spec-based implementation methods.
 	SpecChallengeManager() SpecChallengeManager
+
+	// MaxAssertionsPerChallenge period returns maximum number of assertions that
+	// may need to be processed during a challenge period of blocks.
+	MaxAssertionsPerChallengePeriod() uint64
 }
 
 // InheritedTimer for an edge from its children or claiming edges.

--- a/challenge-manager/BUILD.bazel
+++ b/challenge-manager/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//runtime",
         "//time",
         "//util/stopwaiter",
+        "@com_github_ccoveille_go_safecast//:go-safecast",
         "@com_github_ethereum_go_ethereum//accounts/abi/bind",
         "@com_github_ethereum_go_ethereum//common",
         "@com_github_ethereum_go_ethereum//core/types",

--- a/challenge-manager/manager_test.go
+++ b/challenge-manager/manager_test.go
@@ -257,6 +257,7 @@ func setupValidator(ctx context.Context, t *testing.T) (*Manager, *mocks.MockPro
 	cm := &mocks.MockSpecChallengeManager{}
 	p.On("CurrentChallengeManager", ctx).Return(cm, nil)
 	p.On("SpecChallengeManager").Return(cm)
+	p.On("MaxAssertionsPerChallengePeriod").Return(uint64(100))
 	cm.On("NumBigSteps").Return(uint8(1))
 	s := &mocks.MockStateManager{}
 	cfg, err := setup.ChainsWithEdgeChallengeManager(setup.WithMockOneStepProver())

--- a/testing/mocks/mocks.go
+++ b/testing/mocks/mocks.go
@@ -468,9 +468,14 @@ func (m *MockProtocol) NumAssertions(ctx context.Context) (uint64, error) {
 	return args.Get(0).(uint64), args.Error(1)
 }
 
-func (m *MockProtocol) MinAssertionPeriodBlocks(ctx context.Context) (uint64, error) {
-	args := m.Called(ctx)
-	return args.Get(0).(uint64), args.Error(1)
+func (m *MockProtocol) MinAssertionPeriodBlocks() uint64 {
+	args := m.Called()
+	return args.Get(0).(uint64)
+}
+
+func (m *MockProtocol) MaxAssertionsPerChallengePeriod() uint64 {
+	args := m.Called()
+	return args.Get(0).(uint64)
 }
 
 func (m *MockProtocol) GetAssertion(ctx context.Context, opts *bind.CallOpts, id protocol.AssertionHash) (protocol.Assertion, error) {


### PR DESCRIPTION
Specifically, calculates the number of assertions that are needed per challenge period based on the number of blocks in a challenge period and the minimum number of blocks required between assertions.

This PR is related to NIT-2955