### PR TITLE
Disallow nil as an option for the previousGlobalState

### DIFF
--- a/assertions/manager.go
+++ b/assertions/manager.go
@@ -259,7 +259,7 @@ func (m *Manager) checkLatestDesiredBlock(ctx context.Context) {
 
 func (m *Manager) ExecutionStateAfterParent(ctx context.Context, parentInfo *protocol.AssertionCreatedInfo) (*protocol.ExecutionState, error) {
 	goGlobalState := protocol.GoGlobalStateFromSolidity(parentInfo.AfterState.GlobalState)
-	return m.execProvider.ExecutionStateAfterPreviousState(ctx, parentInfo.InboxMaxCount.Uint64(), &goGlobalState)
+	return m.execProvider.ExecutionStateAfterPreviousState(ctx, parentInfo.InboxMaxCount.Uint64(), goGlobalState)
 }
 
 func (m *Manager) ForksDetected() uint64 {

--- a/assertions/manager_test.go
+++ b/assertions/manager_test.go
@@ -102,7 +102,7 @@ func TestSkipsProcessingAssertionFromEvilFork(t *testing.T) {
 	// charlie's attempt below will fail because the rival assertion he is trying
 	// to post already exists.
 	genesisGlobalState := protocol.GoGlobalStateFromSolidity(genesisCreationInfo.AfterState.GlobalState)
-	bobPostState, err := bobStateManager.ExecutionStateAfterPreviousState(ctx, 1, &genesisGlobalState)
+	bobPostState, err := bobStateManager.ExecutionStateAfterPreviousState(ctx, 1, genesisGlobalState)
 	require.NoError(t, err)
 	t.Logf("%+v", bobPostState)
 	bobAssertion, err := bobChain.NewStakeOnNewAssertion(
@@ -151,11 +151,11 @@ func TestSkipsProcessingAssertionFromEvilFork(t *testing.T) {
 		},
 	)
 
-	genesisState, err := bobStateManager.ExecutionStateAfterPreviousState(ctx, 0, nil)
+	genesisState, err := bobStateManager.ExecutionStateAfterPreviousState(ctx, 0, protocol.GoGlobalState{})
 	require.NoError(t, err)
-	preState, err := bobStateManager.ExecutionStateAfterPreviousState(ctx, 1, &genesisState.GlobalState)
+	preState, err := bobStateManager.ExecutionStateAfterPreviousState(ctx, 1, genesisState.GlobalState)
 	require.NoError(t, err)
-	bobPostState, err = bobStateManager.ExecutionStateAfterPreviousState(ctx, 2, &preState.GlobalState)
+	bobPostState, err = bobStateManager.ExecutionStateAfterPreviousState(ctx, 2, preState.GlobalState)
 	require.NoError(t, err)
 	_, err = bobChain.StakeOnNewAssertion(
 		ctx,
@@ -225,9 +225,9 @@ func TestComplexAssertionForkScenario(t *testing.T) {
 	bobStateManager, err := statemanager.NewForSimpleMachine(t, stateManagerOpts...)
 	require.NoError(t, err)
 
-	genesisState, err := aliceStateManager.ExecutionStateAfterPreviousState(ctx, 0, nil)
+	genesisState, err := aliceStateManager.ExecutionStateAfterPreviousState(ctx, 0, protocol.GoGlobalState{})
 	require.NoError(t, err)
-	alicePostState, err := aliceStateManager.ExecutionStateAfterPreviousState(ctx, 1, &genesisState.GlobalState)
+	alicePostState, err := aliceStateManager.ExecutionStateAfterPreviousState(ctx, 1, genesisState.GlobalState)
 	require.NoError(t, err)
 
 	t.Logf("New stake from alice at post state %+v\n", alicePostState)
@@ -238,7 +238,7 @@ func TestComplexAssertionForkScenario(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	bobPostState, err := bobStateManager.ExecutionStateAfterPreviousState(ctx, 1, &genesisState.GlobalState)
+	bobPostState, err := bobStateManager.ExecutionStateAfterPreviousState(ctx, 1, genesisState.GlobalState)
 	require.NoError(t, err)
 	_, err = bobChain.NewStakeOnNewAssertion(
 		ctx,
@@ -271,9 +271,9 @@ func TestComplexAssertionForkScenario(t *testing.T) {
 		prevInfo, err2 := aliceChain.ReadAssertionCreationInfo(ctx, aliceAssertion.Id())
 		require.NoError(t, err2)
 		prevGlobalState := protocol.GoGlobalStateFromSolidity(prevInfo.AfterState.GlobalState)
-		preState, err2 := aliceStateManager.ExecutionStateAfterPreviousState(ctx, casttest.ToUint64(t, batch-1), &prevGlobalState)
+		preState, err2 := aliceStateManager.ExecutionStateAfterPreviousState(ctx, casttest.ToUint64(t, batch-1), prevGlobalState)
 		require.NoError(t, err2)
-		alicePostState, err2 = aliceStateManager.ExecutionStateAfterPreviousState(ctx, casttest.ToUint64(t, batch), &preState.GlobalState)
+		alicePostState, err2 = aliceStateManager.ExecutionStateAfterPreviousState(ctx, casttest.ToUint64(t, batch), preState.GlobalState)
 		require.NoError(t, err2)
 		t.Logf("Moving stake from alice at post state %+v\n", alicePostState)
 		aliceAssertion, err = aliceChain.StakeOnNewAssertion(
@@ -390,9 +390,9 @@ func TestFastConfirmation(t *testing.T) {
 	require.NoError(t, err)
 	chalManager.Start(ctx)
 
-	preState, err := stateManager.ExecutionStateAfterPreviousState(ctx, 0, nil)
+	preState, err := stateManager.ExecutionStateAfterPreviousState(ctx, 0, protocol.GoGlobalState{})
 	require.NoError(t, err)
-	postState, err := stateManager.ExecutionStateAfterPreviousState(ctx, 1, &preState.GlobalState)
+	postState, err := stateManager.ExecutionStateAfterPreviousState(ctx, 1, preState.GlobalState)
 	require.NoError(t, err)
 
 	time.Sleep(time.Second)
@@ -464,9 +464,9 @@ func TestFastConfirmationWithSafe(t *testing.T) {
 	require.NoError(t, err)
 	chalManagerAlice.Start(ctx)
 
-	preState, err := stateManager.ExecutionStateAfterPreviousState(ctx, 0, nil)
+	preState, err := stateManager.ExecutionStateAfterPreviousState(ctx, 0, protocol.GoGlobalState{})
 	require.NoError(t, err)
-	postState, err := stateManager.ExecutionStateAfterPreviousState(ctx, 1, &preState.GlobalState)
+	postState, err := stateManager.ExecutionStateAfterPreviousState(ctx, 1, preState.GlobalState)
 	require.NoError(t, err)
 
 	time.Sleep(time.Second)

--- a/assertions/poster_test.go
+++ b/assertions/poster_test.go
@@ -75,9 +75,9 @@ func TestPostAssertion(t *testing.T) {
 	require.NoError(t, err)
 	chalManager.Start(ctx)
 
-	preState, err := stateManager.ExecutionStateAfterPreviousState(ctx, 0, nil)
+	preState, err := stateManager.ExecutionStateAfterPreviousState(ctx, 0, protocol.GoGlobalState{})
 	require.NoError(t, err)
-	postState, err := stateManager.ExecutionStateAfterPreviousState(ctx, 1, &preState.GlobalState)
+	postState, err := stateManager.ExecutionStateAfterPreviousState(ctx, 1, preState.GlobalState)
 	require.NoError(t, err)
 
 	time.Sleep(time.Second)

--- a/assertions/sync_test.go
+++ b/assertions/sync_test.go
@@ -67,9 +67,9 @@ func Test_extractAssertionFromEvent(t *testing.T) {
 	aliceStateManager, err := statemanager.NewForSimpleMachine(t, stateManagerOpts...)
 	require.NoError(t, err)
 
-	preState, err := aliceStateManager.ExecutionStateAfterPreviousState(ctx, 0, nil)
+	preState, err := aliceStateManager.ExecutionStateAfterPreviousState(ctx, 0, protocol.GoGlobalState{})
 	require.NoError(t, err)
-	postState, err := aliceStateManager.ExecutionStateAfterPreviousState(ctx, 1, &preState.GlobalState)
+	postState, err := aliceStateManager.ExecutionStateAfterPreviousState(ctx, 1, preState.GlobalState)
 	require.NoError(t, err)
 	assertion, err := aliceChain.NewStakeOnNewAssertion(
 		ctx,
@@ -248,7 +248,7 @@ type mockStateProvider struct {
 func (m *mockStateProvider) ExecutionStateAfterPreviousState(
 	ctx context.Context,
 	maxInboxCount uint64,
-	previousGlobalState *protocol.GoGlobalState,
+	previousGlobalState protocol.GoGlobalState,
 ) (*protocol.ExecutionState, error) {
 	agreement, ok := m.agreesWith[maxInboxCount]
 	if !ok {

--- a/layer2-state-provider/provider.go
+++ b/layer2-state-provider/provider.go
@@ -64,10 +64,8 @@ type ExecutionProvider interface {
 	// state.
 	// Returns either the state at the batch count maxInboxCount (PosInBatch=0) or
 	// the state LayerZeroHeights.BlockChallengeHeight blokcs after
-	// previousGlobalState, whichever is an earlier state. If previousGlobalState
-	// is nil, this function simply returns the state at maxInboxCount batches
-	// (PosInBatch=0).
-	ExecutionStateAfterPreviousState(ctx context.Context, maxInboxCount uint64, previousGlobalState *protocol.GoGlobalState) (*protocol.ExecutionState, error)
+	// previousGlobalState, whichever is an earlier state.
+	ExecutionStateAfterPreviousState(ctx context.Context, maxInboxCount uint64, previousGlobalState protocol.GoGlobalState) (*protocol.ExecutionState, error)
 }
 
 // AssociatedAssertionMetadata for the tracked edge.

--- a/testing/mocks/mocks.go
+++ b/testing/mocks/mocks.go
@@ -120,7 +120,7 @@ func (m *MockStateManager) AgreesWithHistoryCommitment(
 	return args.Get(0).(bool), args.Error(1)
 }
 
-func (m *MockStateManager) ExecutionStateAfterPreviousState(ctx context.Context, maxInboxCount uint64, previousGlobalState *protocol.GoGlobalState) (*protocol.ExecutionState, error) {
+func (m *MockStateManager) ExecutionStateAfterPreviousState(ctx context.Context, maxInboxCount uint64, previousGlobalState protocol.GoGlobalState) (*protocol.ExecutionState, error) {
 	args := m.Called(ctx, maxInboxCount, previousGlobalState)
 	return args.Get(0).(*protocol.ExecutionState), args.Error(1)
 }

--- a/testing/setup/rollup_stack.go
+++ b/testing/setup/rollup_stack.go
@@ -116,11 +116,11 @@ func CreateTwoValidatorFork(
 	if err != nil {
 		return nil, err
 	}
-	genesis, err := honestStateManager.ExecutionStateAfterPreviousState(ctx, 0, nil)
+	genesis, err := honestStateManager.ExecutionStateAfterPreviousState(ctx, 0, protocol.GoGlobalState{})
 	if err != nil {
 		return nil, err
 	}
-	honestPostState, err := honestStateManager.ExecutionStateAfterPreviousState(ctx, 1, &genesis.GlobalState)
+	honestPostState, err := honestStateManager.ExecutionStateAfterPreviousState(ctx, 1, genesis.GlobalState)
 	if err != nil {
 		return nil, err
 	}
@@ -133,11 +133,11 @@ func CreateTwoValidatorFork(
 		return nil, err
 	}
 
-	genesis, err = evilStateManager.ExecutionStateAfterPreviousState(ctx, 0, nil)
+	genesis, err = evilStateManager.ExecutionStateAfterPreviousState(ctx, 0, protocol.GoGlobalState{})
 	if err != nil {
 		return nil, err
 	}
-	evilPostState, err := evilStateManager.ExecutionStateAfterPreviousState(ctx, 1, &genesis.GlobalState)
+	evilPostState, err := evilStateManager.ExecutionStateAfterPreviousState(ctx, 1, genesis.GlobalState)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This makes the code to implement the ExecutionStateAfterPreviousState more complicated than it needs to be for an edge case (bootstrapping a new chain) that will not only happen infrequently, but, can also be represented with a non-nil zero-value `protocol.GoGlobalState{}` instance.