### PR TITLE
Add support for configuring the rollup stack deployment

### DIFF
--- a/testing/endtoend/backend/anvil_local.go
+++ b/testing/endtoend/backend/anvil_local.go
@@ -221,8 +221,11 @@ func (a *AnvilLocal) DeployRollup(ctx context.Context, opts ...challenge_testing
 			anyTrustFastConfirmer,
 			opts...,
 		),
-		false, // Do not use a mock bridge.
-		true,  // Use a mock one step prover entry.
+		setup.RollupStackConfig{
+			UseMockBridge:          false,
+			UseMockOneStepProver:   true,
+			MinimumAssertionPeriod: 0,
+		},
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not deploy rollup stack")


### PR DESCRIPTION
Of particular interest for the bold protocol, this now allows test authors to pass in a minimumAssertionPeriod. That can be important in proving that overflow assertions do not require waiting for the minimum assertion period number of blocks between the previous assertion and their own.

Part of NIT-2794