### PR TITLE
Respect Context Cancel in time.After Invocations

### DIFF
--- a/assertions/poster.go
+++ b/assertions/poster.go
@@ -223,6 +223,10 @@ func (m *Manager) waitToPostIfNeeded(
 				latestBlockNumber,
 			),
 		)
-		<-time.After(m.times.avgBlockTime)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(m.times.avgBlockTime):
+		}
 	}
 }

--- a/chain-abstraction/sol-implementation/transact.go
+++ b/chain-abstraction/sol-implementation/transact.go
@@ -162,7 +162,11 @@ func (a *AssertionChain) waitForTxToBeSafe(
 				}
 			}
 			timeToWait := a.averageTimeForBlockCreation * time.Duration(blocksLeftForTxToBeSafe)
-			<-time.After(timeToWait)
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(timeToWait):
+			}
 		} else {
 			break
 		}

--- a/challenge-manager/edge-tracker/challenge_confirmation.go
+++ b/challenge-manager/edge-tracker/challenge_confirmation.go
@@ -321,7 +321,11 @@ func (cc *challengeConfirmer) waitForTxToBeSafe(
 				}
 			}
 			timeToWait := cc.averageTimeForBlockCreation * time.Duration(blocksLeftForTxToBeSafe)
-			<-time.After(timeToWait)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(timeToWait):
+			}
 		} else {
 			break
 		}


### PR DESCRIPTION
Not using context cancel in a select block leads to issues in preventing graceful shutdown