### PR TITLE
Improve Issues Around Waiting for Safe Txs

### DIFF
--- a/api/backend/backend.go
+++ b/api/backend/backend.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/ccoveille/go-safecast"
 
@@ -33,7 +32,6 @@ type BusinessLogicProvider interface {
 	GetEdges(ctx context.Context, opts ...db.EdgeOption) ([]*api.JsonEdge, error)
 	GetTrackedRoyalEdges(ctx context.Context) ([]*api.JsonEdgesByChallengedAssertion, error)
 	GetMiniStakes(ctx context.Context, assertionHash protocol.AssertionHash, opts ...db.EdgeOption) (*api.JsonMiniStakes, error)
-	LatestConfirmedAssertion(ctx context.Context) (*api.JsonAssertion, error)
 }
 
 type EdgeTrackerFetcher interface {
@@ -78,24 +76,25 @@ func (b *Backend) GetAssertions(ctx context.Context, opts ...db.AssertionOption)
 		return nil, err
 	}
 	if query.ShouldForceUpdate() {
+		opts := &bind.CallOpts{Context: ctx}
 		for _, a := range assertions {
-			fetchedAssertion, err := b.chainDataFetcher.GetAssertion(ctx, &bind.CallOpts{Context: ctx}, protocol.AssertionHash{Hash: a.Hash})
+			fetchedAssertion, err := b.chainDataFetcher.GetAssertion(ctx, opts, protocol.AssertionHash{Hash: a.Hash})
 			if err != nil {
 				return nil, err
 			}
-			status, err := fetchedAssertion.Status(ctx)
+			status, err := fetchedAssertion.Status(ctx, opts)
 			if err != nil {
 				return nil, err
 			}
-			isFirstChild, err := fetchedAssertion.IsFirstChild()
+			isFirstChild, err := fetchedAssertion.IsFirstChild(ctx, opts)
 			if err != nil {
 				return nil, err
 			}
-			firstChildBlock, err := fetchedAssertion.FirstChildCreationBlock()
+			firstChildBlock, err := fetchedAssertion.FirstChildCreationBlock(ctx, opts)
 			if err != nil {
 				return nil, err
 			}
-			secondChildBlock, err := fetchedAssertion.SecondChildCreationBlock()
+			secondChildBlock, err := fetchedAssertion.SecondChildCreationBlock(ctx, opts)
 			if err != nil {
 				return nil, err
 			}
@@ -286,65 +285,4 @@ func (b *Backend) GetTrackedRoyalEdges(ctx context.Context) ([]*api.JsonEdgesByC
 		})
 	}
 	return edgesByAssertion, nil
-}
-
-func (b *Backend) LatestConfirmedAssertion(ctx context.Context) (*api.JsonAssertion, error) {
-	latestConfirmedAssertion, err := b.chainDataFetcher.LatestConfirmed(ctx, &bind.CallOpts{Context: ctx})
-	if err != nil {
-		return nil, err
-	}
-	hash := latestConfirmedAssertion.Id()
-	creationInfo, err := b.chainDataFetcher.ReadAssertionCreationInfo(ctx, hash)
-	if err != nil {
-		return nil, err
-	}
-	status, err := b.chainDataFetcher.AssertionStatus(ctx, hash)
-	if err != nil {
-		return nil, err
-	}
-	fetchedAssertion, err := b.chainDataFetcher.GetAssertion(ctx, &bind.CallOpts{Context: ctx}, hash)
-	if err != nil {
-		return nil, err
-	}
-	isFirstChild, err := fetchedAssertion.IsFirstChild()
-	if err != nil {
-		return nil, err
-	}
-	firstChildBlock, err := fetchedAssertion.FirstChildCreationBlock()
-	if err != nil {
-		return nil, err
-	}
-	secondChildBlock, err := fetchedAssertion.SecondChildCreationBlock()
-	if err != nil {
-		return nil, err
-	}
-	beforeState := protocol.GoExecutionStateFromSolidity(creationInfo.BeforeState)
-	afterState := protocol.GoExecutionStateFromSolidity(creationInfo.AfterState)
-	return &api.JsonAssertion{
-		Hash:                     hash.Hash,
-		ConfirmPeriodBlocks:      creationInfo.ConfirmPeriodBlocks,
-		RequiredStake:            creationInfo.RequiredStake.String(),
-		ParentAssertionHash:      creationInfo.ParentAssertionHash.Hash,
-		InboxMaxCount:            creationInfo.InboxMaxCount.String(),
-		AfterInboxBatchAcc:       creationInfo.AfterInboxBatchAcc,
-		WasmModuleRoot:           creationInfo.WasmModuleRoot,
-		TransactionHash:          creationInfo.TransactionHash,
-		CreationBlock:            creationInfo.CreationBlock,
-		ChallengeManager:         creationInfo.ChallengeManager,
-		AfterStateBlockHash:      afterState.GlobalState.BlockHash,
-		AfterStateSendRoot:       afterState.GlobalState.SendRoot,
-		AfterStateBatch:          afterState.GlobalState.Batch,
-		AfterStatePosInBatch:     afterState.GlobalState.PosInBatch,
-		AfterStateMachineStatus:  afterState.MachineStatus,
-		BeforeStateBlockHash:     beforeState.GlobalState.BlockHash,
-		BeforeStateSendRoot:      beforeState.GlobalState.SendRoot,
-		BeforeStateBatch:         beforeState.GlobalState.Batch,
-		BeforeStatePosInBatch:    beforeState.GlobalState.PosInBatch,
-		BeforeStateMachineStatus: beforeState.MachineStatus,
-		IsFirstChild:             isFirstChild,
-		FirstChildBlock:          &firstChildBlock,
-		SecondChildBlock:         &secondChildBlock,
-		Status:                   status.String(),
-		LastUpdatedAt:            time.Now(),
-	}, nil
 }

--- a/api/backend/backend.go
+++ b/api/backend/backend.go
@@ -211,7 +211,7 @@ func (b *Backend) GetEdges(ctx context.Context, opts ...db.EdgeOption) ([]*api.J
 			e.TimeUnrivaled = timeUnrivaled
 			isRoyal := b.chainWatcher.IsRoyal(assertionHash, edge.Id())
 			if isRoyal {
-				inheritedTimer, err := b.chainWatcher.SafeHeadInheritedTimer(ctx, edge.Id())
+				inheritedTimer, err := b.chainWatcher.InheritedTimerForEdge(ctx, edge.Id())
 				if err != nil {
 					return nil, err
 				}

--- a/assertions/confirmation.go
+++ b/assertions/confirmation.go
@@ -71,16 +71,17 @@ func (m *Manager) keepTryingAssertionConfirmation(ctx context.Context, assertion
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
+			opts := m.chain.GetCallOptsWithDesiredRpcHeadBlockNumber(&bind.CallOpts{Context: ctx})
 			parentAssertion, err := m.chain.GetAssertion(
 				ctx,
-				m.chain.GetCallOptsWithDesiredRpcHeadBlockNumber(&bind.CallOpts{Context: ctx}),
+				opts,
 				creationInfo.ParentAssertionHash,
 			)
 			if err != nil {
 				log.Error("Could not get parent assertion", "err", err)
 				continue
 			}
-			parentAssertionHasSecondChild, err := parentAssertion.HasSecondChild()
+			parentAssertionHasSecondChild, err := parentAssertion.HasSecondChild(ctx, opts)
 			if err != nil {
 				log.Error("Could not confirm if parent assertion has second child", "err", err)
 				continue

--- a/assertions/sync.go
+++ b/assertions/sync.go
@@ -488,23 +488,24 @@ func (m *Manager) saveAssertionToDB(ctx context.Context, creationInfo *protocol.
 	beforeState := protocol.GoExecutionStateFromSolidity(creationInfo.BeforeState)
 	afterState := protocol.GoExecutionStateFromSolidity(creationInfo.AfterState)
 	assertionHash := creationInfo.AssertionHash
-	status, err := m.chain.AssertionStatus(ctx, assertionHash)
+	// Because the BoLD database is for exploratory purposes, we don't care about using a reorg-safe
+	// RPC block number for reading data here. Latest block number will suffice to ensure we capture
+	// all assertions for data analysis if needed.
+	opts := &bind.CallOpts{Context: ctx}
+	assertion, err := m.chain.GetAssertion(ctx, opts, assertionHash)
 	if err != nil {
 		return err
 	}
-	assertion, err := m.chain.GetAssertion(ctx, &bind.CallOpts{Context: ctx}, assertionHash)
+	status, err := assertion.Status(ctx, opts)
+	isFirstChild, err := assertion.IsFirstChild(ctx, opts)
 	if err != nil {
 		return err
 	}
-	isFirstChild, err := assertion.IsFirstChild()
+	firstChildBlock, err := assertion.SecondChildCreationBlock(ctx, opts)
 	if err != nil {
 		return err
 	}
-	firstChildBlock, err := assertion.SecondChildCreationBlock()
-	if err != nil {
-		return err
-	}
-	secondChildBlock, err := assertion.SecondChildCreationBlock()
+	secondChildBlock, err := assertion.SecondChildCreationBlock(ctx, opts)
 	if err != nil {
 		return err
 	}

--- a/assertions/sync.go
+++ b/assertions/sync.go
@@ -497,6 +497,9 @@ func (m *Manager) saveAssertionToDB(ctx context.Context, creationInfo *protocol.
 		return err
 	}
 	status, err := assertion.Status(ctx, opts)
+	if err != nil {
+		return err
+	}
 	isFirstChild, err := assertion.IsFirstChild(ctx, opts)
 	if err != nil {
 		return err

--- a/chain-abstraction/interfaces.go
+++ b/chain-abstraction/interfaces.go
@@ -106,13 +106,13 @@ const ChallengeGracePeriodNotPassedAssertionConfirmationError = "CHALLENGE_GRACE
 // Assertions can be challenged.
 type Assertion interface {
 	Id() AssertionHash
-	PrevId(ctx context.Context) (AssertionHash, error)
-	HasSecondChild() (bool, error)
-	FirstChildCreationBlock() (uint64, error)
-	SecondChildCreationBlock() (uint64, error)
-	IsFirstChild() (bool, error)
 	CreatedAtBlock() uint64
-	Status(ctx context.Context) (AssertionStatus, error)
+	PrevId(ctx context.Context) (AssertionHash, error)
+	HasSecondChild(ctx context.Context, opts *bind.CallOpts) (bool, error)
+	FirstChildCreationBlock(ctx context.Context, opts *bind.CallOpts) (uint64, error)
+	SecondChildCreationBlock(ctx context.Context, opts *bind.CallOpts) (uint64, error)
+	IsFirstChild(ctx context.Context, opts *bind.CallOpts) (bool, error)
+	Status(ctx context.Context, opts *bind.CallOpts) (AssertionStatus, error)
 }
 
 // AssertionCreatedInfo from an event creation.
@@ -157,6 +157,7 @@ type AssertionChain interface {
 		ctx context.Context, id AssertionHash,
 	) (*AssertionCreatedInfo, error)
 	GetCallOptsWithDesiredRpcHeadBlockNumber(opts *bind.CallOpts) *bind.CallOpts
+	GetDesiredRpcHeadBlockNumber() rpc.BlockNumber
 
 	MinAssertionPeriodBlocks() uint64
 	AssertionUnrivaledBlocks(ctx context.Context, assertionHash AssertionHash) (uint64, error)
@@ -412,11 +413,8 @@ type ReadOnlyEdge interface {
 	AssertionHash(ctx context.Context) (AssertionHash, error)
 	// The time in seconds an edge has been unrivaled.
 	TimeUnrivaled(ctx context.Context) (uint64, error)
-	// The inherited timer from the edge's children or claiming edges based on the latest block number.
-	// NOT reorg safe.
+	// The inherited timer from the edge's children or claiming edges based on the configured block number.
 	LatestInheritedTimer(ctx context.Context) (InheritedTimer, error)
-	// The inherited timer from the edge's children or claiming edges based on the safe block number.
-	SafeHeadInheritedTimer(ctx context.Context) (InheritedTimer, error)
 	// Whether or not an edge has rivals.
 	HasRival(ctx context.Context) (bool, error)
 	// The status of an edge.

--- a/chain-abstraction/sol-implementation/assertion_chain.go
+++ b/chain-abstraction/sol-implementation/assertion_chain.go
@@ -1191,3 +1191,7 @@ func (a *AssertionChain) GetCallOptsWithSafeBlockNumber(opts *bind.CallOpts) *bi
 	opts.BlockNumber = big.NewInt(int64(rpc.SafeBlockNumber))
 	return opts
 }
+
+func (a *AssertionChain) GetDesiredRpcHeadBlockNumber() rpc.BlockNumber {
+	return a.rpcHeadBlockNumber
+}

--- a/chain-abstraction/sol-implementation/edge_challenge_manager.go
+++ b/chain-abstraction/sol-implementation/edge_challenge_manager.go
@@ -584,21 +584,6 @@ func (cm *specChallengeManager) GetEdge(
 	})), nil
 }
 
-func (e *specEdge) SafeHeadInheritedTimer(ctx context.Context) (protocol.InheritedTimer, error) {
-	edge, err := e.manager.caller.GetEdge(e.manager.assertionChain.GetCallOptsWithSafeBlockNumber(&bind.CallOpts{Context: ctx}), e.id)
-	if err != nil {
-		return 0, err
-	}
-	if edgetracker.IsRootBlockChallengeEdge(e) {
-		assertionUnrivaledBlocks, err := e.manager.assertionChain.AssertionUnrivaledBlocks(ctx, protocol.AssertionHash{Hash: common.Hash(e.ClaimId().Unwrap())})
-		if err != nil {
-			return 0, err
-		}
-		return protocol.InheritedTimer(edge.TotalTimeUnrivaledCache + assertionUnrivaledBlocks), nil
-	}
-	return protocol.InheritedTimer(edge.TotalTimeUnrivaledCache), nil
-}
-
 func (e *specEdge) LatestInheritedTimer(ctx context.Context) (protocol.InheritedTimer, error) {
 	edge, err := e.manager.caller.GetEdge(e.manager.assertionChain.GetCallOptsWithDesiredRpcHeadBlockNumber(&bind.CallOpts{Context: ctx}), e.id)
 	if err != nil {

--- a/chain-abstraction/sol-implementation/transact.go
+++ b/chain-abstraction/sol-implementation/transact.go
@@ -144,10 +144,14 @@ func (a *AssertionChain) waitForTxToBeSafe(
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
-		latestSafeHeaderNumber, err := backend.HeaderU64(ctx)
+		latestSafeHeader, err := backend.HeaderByNumber(ctx, big.NewInt(int64(a.rpcHeadBlockNumber)))
 		if err != nil {
 			return nil, err
 		}
+		if !latestSafeHeader.Number.IsUint64() {
+			return nil, errors.New("block number is not uint64")
+		}
+		latestSafeHeaderNumber := latestSafeHeader.Number.Uint64()
 		txSafe := latestSafeHeaderNumber >= receipt.BlockNumber.Uint64()
 
 		// If the tx is not yet safe, we can simply wait.

--- a/chain-abstraction/sol-implementation/types.go
+++ b/chain-abstraction/sol-implementation/types.go
@@ -53,21 +53,21 @@ func (a *Assertion) PrevId(ctx context.Context) (protocol.AssertionHash, error) 
 	return a.prevId.Unwrap(), nil
 }
 
-func (a *Assertion) HasSecondChild() (bool, error) {
+func (a *Assertion) HasSecondChild(ctx context.Context, opts *bind.CallOpts) (bool, error) {
 	if a.secondChildBlock.IsSome() {
 		return a.secondChildBlock.Unwrap() > 0, nil
 	}
-	inner, err := a.inner()
+	inner, err := a.inner(ctx, opts)
 	if err != nil {
 		return false, err
 	}
 	return inner.SecondChildBlock > 0, nil
 }
 
-func (a *Assertion) inner() (*rollupgen.AssertionNode, error) {
+func (a *Assertion) inner(ctx context.Context, opts *bind.CallOpts) (*rollupgen.AssertionNode, error) {
 	var b [32]byte
 	copy(b[:], a.id.Bytes())
-	assertionNode, err := a.chain.userLogic.GetAssertion(a.chain.GetCallOptsWithDesiredRpcHeadBlockNumber(&bind.CallOpts{}), b)
+	assertionNode, err := a.chain.userLogic.GetAssertion(opts, b)
 	if err != nil {
 		return nil, err
 	}
@@ -94,31 +94,31 @@ func (a *Assertion) inner() (*rollupgen.AssertionNode, error) {
 	}
 	return &assertionNode, nil
 }
-func (a *Assertion) FirstChildCreationBlock() (uint64, error) {
+func (a *Assertion) FirstChildCreationBlock(ctx context.Context, opts *bind.CallOpts) (uint64, error) {
 	if a.firstChildBlock.IsSome() {
 		return a.firstChildBlock.Unwrap(), nil
 	}
-	inner, err := a.inner()
+	inner, err := a.inner(ctx, opts)
 	if err != nil {
 		return 0, err
 	}
 	return inner.FirstChildBlock, nil
 }
-func (a *Assertion) SecondChildCreationBlock() (uint64, error) {
+func (a *Assertion) SecondChildCreationBlock(ctx context.Context, opts *bind.CallOpts) (uint64, error) {
 	if a.secondChildBlock.IsSome() {
 		return a.secondChildBlock.Unwrap(), nil
 	}
-	inner, err := a.inner()
+	inner, err := a.inner(ctx, opts)
 	if err != nil {
 		return 0, err
 	}
 	return inner.SecondChildBlock, nil
 }
-func (a *Assertion) IsFirstChild() (bool, error) {
+func (a *Assertion) IsFirstChild(ctx context.Context, opts *bind.CallOpts) (bool, error) {
 	if a.isFirstChild {
 		return a.isFirstChild, nil
 	}
-	inner, err := a.inner()
+	inner, err := a.inner(ctx, opts)
 	if err != nil {
 		return false, err
 	}
@@ -127,11 +127,11 @@ func (a *Assertion) IsFirstChild() (bool, error) {
 func (a *Assertion) CreatedAtBlock() uint64 {
 	return a.createdAt
 }
-func (a *Assertion) Status(ctx context.Context) (protocol.AssertionStatus, error) {
+func (a *Assertion) Status(ctx context.Context, opts *bind.CallOpts) (protocol.AssertionStatus, error) {
 	if a.isConfirmed {
 		return protocol.AssertionConfirmed, nil
 	}
-	inner, err := a.inner()
+	inner, err := a.inner(ctx, opts)
 	if err != nil {
 		return 0, err
 	}

--- a/challenge-manager/chain-watcher/watcher.go
+++ b/challenge-manager/chain-watcher/watcher.go
@@ -166,7 +166,7 @@ func (w *Watcher) IsRoyal(assertionHash protocol.AssertionHash, edgeId protocol.
 	return chal.honestEdgeTree.HasRoyalEdge(edgeId)
 }
 
-func (w *Watcher) SafeHeadInheritedTimer(
+func (w *Watcher) InheritedTimerForEdge(
 	ctx context.Context,
 	edgeId protocol.EdgeId,
 ) (protocol.InheritedTimer, error) {
@@ -179,7 +179,7 @@ func (w *Watcher) SafeHeadInheritedTimer(
 		return 0, fmt.Errorf("no edge found with id %#x", edgeId.Hash)
 
 	}
-	return edgeOpt.Unwrap().SafeHeadInheritedTimer(ctx)
+	return edgeOpt.Unwrap().LatestInheritedTimer(ctx)
 }
 
 func (w *Watcher) IsSynced() bool {
@@ -981,7 +981,7 @@ func (w *Watcher) saveEdgeToDB(
 	if edge.ClaimId().IsSome() {
 		claimId = common.Hash(edge.ClaimId().Unwrap())
 	}
-	inheritedTimer, err := w.SafeHeadInheritedTimer(ctx, edge.Id())
+	inheritedTimer, err := w.InheritedTimerForEdge(ctx, edge.Id())
 	if err != nil {
 		return err
 	}

--- a/challenge-manager/challenge-tree/mock/edge.go
+++ b/challenge-manager/challenge-tree/mock/edge.go
@@ -133,11 +133,6 @@ func (*Edge) TimeUnrivaled(_ context.Context) (uint64, error) {
 	return 0, nil
 }
 
-// SafeHeadInheritedTimer in seconds an edge has been unrivaled.
-func (e *Edge) SafeHeadInheritedTimer(_ context.Context) (protocol.InheritedTimer, error) {
-	return e.InnerInheritedTimer, nil
-}
-
 // LatestInheritedTimer in seconds an edge has been unrivaled.
 func (e *Edge) LatestInheritedTimer(_ context.Context) (protocol.InheritedTimer, error) {
 	return e.InnerInheritedTimer, nil

--- a/testing/mocks/BUILD.bazel
+++ b/testing/mocks/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "@com_github_ethereum_go_ethereum//accounts/abi/bind",
         "@com_github_ethereum_go_ethereum//common",
         "@com_github_ethereum_go_ethereum//core/types",
+        "@com_github_ethereum_go_ethereum//rpc",
         "@com_github_stretchr_testify//mock",
     ],
 )

--- a/testing/mocks/mocks.go
+++ b/testing/mocks/mocks.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/offchainlabs/bold/api/db"
 	protocol "github.com/offchainlabs/bold/chain-abstraction"
@@ -428,8 +429,8 @@ func (m *MockProtocol) GetCallOptsWithDesiredRpcHeadBlockNumber(opts *bind.CallO
 	return opts
 }
 
-func (m *MockProtocol) GetDesiredRpcHeadBlockNumber() *big.Int {
-	return nil
+func (m *MockProtocol) GetDesiredRpcHeadBlockNumber() rpc.BlockNumber {
+	return rpc.LatestBlockNumber
 }
 
 // Read-only methods.

--- a/testing/mocks/mocks.go
+++ b/testing/mocks/mocks.go
@@ -312,11 +312,6 @@ func (m *MockSpecEdge) LatestInheritedTimer(ctx context.Context) (protocol.Inher
 	return args.Get(0).(protocol.InheritedTimer), args.Error(1)
 }
 
-func (m *MockSpecEdge) SafeHeadInheritedTimer(ctx context.Context) (protocol.InheritedTimer, error) {
-	args := m.Called(ctx)
-	return args.Get(0).(protocol.InheritedTimer), args.Error(1)
-}
-
 func (m *MockSpecEdge) HasRival(ctx context.Context) (bool, error) {
 	args := m.Called(ctx)
 	return args.Get(0).(bool), args.Error(1)


### PR DESCRIPTION
This PR fixes a bug in the functions `waitForTxToBeSafe` inside the BoLD repo. These functions used to check that a tx receipt has passed a configured, `safe` block number. However, in a bad merge, it was edited to just compare against `latest`, which was incorrect. This led to a variety of UX issues in the BoLD v2 testnet and more egregious errors around attempting to send a ton of timer update txs at the end of a challenge.

This PR also fixes the DB methods to use `latest` block number, as it is important our DB captures all data that is posted, even if it is reorged later. The DB does not need to be reorg safe as it is purely for informational purposes and data analysis. We also a removed a method to fetch the latest confirmed assertion via the rest API, as this can easily be retrieved via other means. The reason it was removed is because it was using several methods that were hard to configure the block number for, and it is just unnecessary in general.