### PR TITLE
Skip AutoDeposit if Staked, Use Latest Data for Auto-Operations

### DIFF
--- a/assertions/manager.go
+++ b/assertions/manager.go
@@ -286,7 +286,7 @@ func (m *Manager) Start(ctx context.Context) {
 				if err2 != nil {
 					return false, err2
 				}
-				if err2 := m.chain.Deposit(ctx, latestConfirmedInfo.RequiredStake); err2 != nil {
+				if err2 := m.chain.AutoDepositTokenForStaking(ctx, latestConfirmedInfo.RequiredStake); err2 != nil {
 					return false, err2
 				}
 				return true, nil

--- a/chain-abstraction/interfaces.go
+++ b/chain-abstraction/interfaces.go
@@ -166,7 +166,7 @@ type AssertionChain interface {
 	TopLevelClaimHeights(ctx context.Context, edgeId EdgeId) (OriginHeights, error)
 
 	// Mutating methods.
-	Deposit(
+	AutoDepositTokenForStaking(
 		ctx context.Context,
 		amount *big.Int,
 	) error

--- a/testing/mocks/mocks.go
+++ b/testing/mocks/mocks.go
@@ -557,7 +557,7 @@ func (m *MockProtocol) IsStaked(ctx context.Context) (bool, error) {
 	return args.Get(0).(bool), args.Error(1)
 }
 
-func (m *MockProtocol) Deposit(
+func (m *MockProtocol) AutoDepositTokenForStaking(
 	ctx context.Context,
 	amount *big.Int,
 ) error {


### PR DESCRIPTION
This PR fixes a bug where auto-depositing stake token (wrapping ETH to WETH) was checking balances using "finalized" data, and not checking if the validator was already staked. This would lead to a situation where if the validator deposits, then the process restarts, the validator will attempt to deposit a second time because the tx is not yet final. Moreover, it should not even attempt an auto-deposit if already staked.