### PR TITLE
Add a small sleep (1/10 average block time) when chain is behind

### DIFF
--- a/assertions/poster.go
+++ b/assertions/poster.go
@@ -155,6 +155,8 @@ func (m *Manager) PostAssertionBasedOnParent(
 				"latestStakedAssertionBatchCount", batchCount,
 				"latestStakedAssertionBlockHash", containers.Trunc(parentBlockHash[:]),
 			)
+			// If the chain is catching up, we wait for a bit and try again.
+			time.Sleep(m.times.avgBlockTime / 10)
 			return none, nil
 		}
 		return none, errors.Wrapf(err, "could not get execution state at batch count %d with parent block hash %v", batchCount, parentBlockHash)

--- a/assertions/sync.go
+++ b/assertions/sync.go
@@ -279,6 +279,8 @@ func (m *Manager) findCanonicalAssertionBranch(
 					chainCatchingUpCounter.Inc(1)
 					log.Info("Chain still syncing "+
 						"will reattempt processing when caught up", "err", err)
+					// If the chain is catching up, we wait for a bit and try again.
+					time.Sleep(m.times.avgBlockTime / 10)
 					return false, l2stateprovider.ErrChainCatchingUp
 				case err != nil:
 					return false, err


### PR DESCRIPTION
This just cuts down on log-spam slightly. Without the sleep, there were sometimes hundreds of log lines saying that the chain was still catching up. And, that means there were also a bunch of tight RPC calls.