### PR TITLE
Fix New Stake Method

### DIFF
--- a/chain-abstraction/sol-implementation/assertion_chain.go
+++ b/chain-abstraction/sol-implementation/assertion_chain.go
@@ -504,16 +504,8 @@ func (a *AssertionChain) NewStake(
 	if staked {
 		return nil
 	}
-	latestConfirmed, err := a.LatestConfirmed(ctx, a.GetCallOptsWithDesiredRpcHeadBlockNumber(&bind.CallOpts{Context: ctx}))
-	if err != nil {
-		return err
-	}
-	info, err := a.ReadAssertionCreationInfo(ctx, latestConfirmed.Id())
-	if err != nil {
-		return err
-	}
 	_, err = a.transact(ctx, a.backend, func(opts *bind.TransactOpts) (*types.Transaction, error) {
-		return a.userLogic.RollupUserLogicTransactor.NewStake(opts, info.RequiredStake, a.withdrawalAddress)
+		return a.userLogic.RollupUserLogicTransactor.NewStake(opts, new(big.Int), a.withdrawalAddress)
 	})
 	return err
 }

--- a/chain-abstraction/sol-implementation/assertion_chain.go
+++ b/chain-abstraction/sol-implementation/assertion_chain.go
@@ -501,7 +501,7 @@ func (a *AssertionChain) NewStake(
 	if err != nil {
 		return err
 	}
-	if !staked {
+	if staked {
 		return nil
 	}
 	latestConfirmed, err := a.LatestConfirmed(ctx, a.GetCallOptsWithDesiredRpcHeadBlockNumber(&bind.CallOpts{Context: ctx}))

--- a/chain-abstraction/sol-implementation/assertion_chain_test.go
+++ b/chain-abstraction/sol-implementation/assertion_chain_test.go
@@ -27,6 +27,17 @@ import (
 	"github.com/offchainlabs/bold/testing/setup"
 )
 
+func TestNewEmptyStake(t *testing.T) {
+	ctx := context.Background()
+	cfg, err := setup.ChainsWithEdgeChallengeManager()
+	require.NoError(t, err)
+	chain := cfg.Chains[0]
+	require.NoError(t, chain.NewStake(ctx))
+	isStaked, err := chain.IsStaked(ctx)
+	require.NoError(t, err)
+	require.True(t, isStaked)
+}
+
 func TestNewStakeOnNewAssertion(t *testing.T) {
 	ctx := context.Background()
 	cfg, err := setup.ChainsWithEdgeChallengeManager()


### PR DESCRIPTION
The new stake function was untested, and is important for automating delegated stakers. A boolean was incorrect, and the wrong value was passed into the actual staking mechanism