### PR TITLE
Correctly reset handlers for gasEstimation related ephemeral error and fix Start and End values in FilterLogs query

### DIFF
--- a/assertions/confirmation.go
+++ b/assertions/confirmation.go
@@ -108,6 +108,7 @@ func (m *Manager) keepTryingAssertionConfirmation(ctx context.Context, assertion
 			}
 
 			exceedsMaxMempoolSizeEphemeralErrorHandler.Reset()
+			gasEstimationEphemeralErrorHandler.Reset()
 
 			if confirmed {
 				assertionConfirmedCounter.Inc(1)

--- a/assertions/poster.go
+++ b/assertions/poster.go
@@ -64,6 +64,7 @@ func (m *Manager) postAssertionRoutine(ctx context.Context) {
 			}
 		} else {
 			exceedsMaxMempoolSizeEphemeralErrorHandler.Reset()
+			gasEstimationEphemeralErrorHandler.Reset()
 		}
 
 		select {

--- a/challenge-manager/chain-watcher/watcher.go
+++ b/challenge-manager/chain-watcher/watcher.go
@@ -256,6 +256,10 @@ func (w *Watcher) Start(ctx context.Context) {
 				log.Error("Could not get latest header", "err", err)
 				continue
 			}
+			if fromBlock > toBlock { // Due to Reorg. In which case we rewind fromBlock
+				fromBlock = toBlock
+				continue
+			}
 			if fromBlock == toBlock {
 				w.initialSyncCompleted.Store(true)
 				continue
@@ -912,6 +916,7 @@ func (w *Watcher) confirmAssertionByChallengeWinner(ctx context.Context, edge pr
 			}
 
 			exceedsMaxMempoolSizeEphemeralErrorHandler.Reset()
+			gasEstimationEphemeralErrorHandler.Reset()
 
 			if confirmed {
 				assertionConfirmedCounter.Inc(1)

--- a/challenge-manager/chain-watcher/watcher.go
+++ b/challenge-manager/chain-watcher/watcher.go
@@ -256,7 +256,9 @@ func (w *Watcher) Start(ctx context.Context) {
 				log.Error("Could not get latest header", "err", err)
 				continue
 			}
-			if fromBlock > toBlock { // Due to Reorg. In which case we rewind fromBlock
+			// Might happen due to Reorgs when assertionChain's rpcHeadBlockNumber is not set to finalized, and in case it is set to finalized
+			// this might occur due to l1 backends of load balancer not being in consensus wrt finalized. In which case we rewind fromBlock
+			if fromBlock > toBlock {
 				fromBlock = toBlock
 				continue
 			}

--- a/challenge-manager/chain-watcher/watcher.go
+++ b/challenge-manager/chain-watcher/watcher.go
@@ -256,10 +256,9 @@ func (w *Watcher) Start(ctx context.Context) {
 				log.Error("Could not get latest header", "err", err)
 				continue
 			}
-			// Might happen due to Reorgs when assertionChain's rpcHeadBlockNumber is not set to finalized, and in case it is set to finalized
-			// this might occur due to l1 backends of load balancer not being in consensus wrt finalized. In which case we rewind fromBlock
+			// AssertionChain's rpcHeadBlockNumber is set to finalized and this might occur due to l1 backends of load balancer
+			// not being in consensus wrt finalized. In which case we ignore and continue
 			if fromBlock > toBlock {
-				fromBlock = toBlock
 				continue
 			}
 			if fromBlock == toBlock {


### PR DESCRIPTION
Previously we were not resetting handlers for gasEstimation related ephemeral error of the form `gas estimation errored for tx with hash`, this meant these errors were unnecessarily loud, this PR fixes this by correctly resetting such handlers.

There was another issue in `chain-watcher/watcher.go` where the `FilterOpts` for corresponding `FilterLogs` query would have incorrect start and end values during a reorg (as there is a possibility for `toBlock` to fall behind `fromBlock`), thus leading to avoidable loud errors- 
```
{"t":"2025-03-17T06:08:30.39179413Z","lvl":"error","msg":"Could not check for edge added","err":"invalid block range params"}
```
fixed by rewinding `fromBlock` to `toBlock`.

Corresponding Nitro PR- https://github.com/OffchainLabs/nitro/pull/3032
Part of NIT-3148