### PR TITLE
Expose a Parent Chain Block Time Option for the Assertion Chain Struct in BoLD

### DIFF
--- a/chain-abstraction/sol-implementation/assertion_chain.go
+++ b/chain-abstraction/sol-implementation/assertion_chain.go
@@ -167,6 +167,14 @@ func WithFastConfirmation() Opt {
 	}
 }
 
+// WithParentChainBlockCreationTime sets the average time for block creation of the chain where
+// assertions are posted to and fetched from.
+func WithParentChainBlockCreationTime(d time.Duration) Opt {
+	return func(a *AssertionChain) {
+		a.averageTimeForBlockCreation = d
+	}
+}
+
 // NewAssertionChain instantiates an assertion chain
 // instance from a chain backend and provided options.
 func NewAssertionChain(


### PR DESCRIPTION
Every other place in the BoLD repo lets a user customize the parent chain block time on initialization, _except_ the assertion chain. This blocks L3 support for BoLD