### PR TITLE
Support logging at different level for ephemeral BoLD errors

### DIFF
--- a/assertions/sync.go
+++ b/assertions/sync.go
@@ -294,7 +294,7 @@ func (m *Manager) findCanonicalAssertionBranch(
 					return false, err
 				}
 				return expectedState.Equals(protocol.GoExecutionStateFromSolidity(assertion.AfterState)), nil
-			})
+			}, func(rc *retry.RetryConfig) { rc.LevelWarningError = "could not check if we have result at count" })
 			if err != nil {
 				return errors.New("could not check for assertion agreements")
 			}


### PR DESCRIPTION
This PR makes it that the BoLD retry error in not finding message results for future blocks is logged as a warning instead as an error. Below is the log line that will be logged at warning and other errors would continue to log at level Error.
```
 Could not succeed function after retries retryCount=15 err="<validator-name>: could not check if we have result at count <msgIndex>: result not found" 
```

Corresponding nitro PR- https://github.com/OffchainLabs/nitro/pull/3171
Part of NIT-3158