### PR TITLE
Refractor PostAssertionBasedOnParent to avoid calling ReadAssertionCreationInfo

### DIFF
--- a/assertions/manager_test.go
+++ b/assertions/manager_test.go
@@ -404,7 +404,9 @@ func TestFastConfirmation(t *testing.T) {
 	posted, err := assertionManager.PostAssertion(ctx)
 	require.NoError(t, err)
 	require.Equal(t, true, posted.IsSome())
-	require.Equal(t, postState, protocol.GoExecutionStateFromSolidity(posted.Unwrap().AfterState))
+	creationInfo, err := aliceChain.ReadAssertionCreationInfo(ctx, posted.Unwrap().Id())
+	require.NoError(t, err)
+	require.Equal(t, postState, protocol.GoExecutionStateFromSolidity(creationInfo.AfterState))
 
 	ctx, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()
@@ -479,10 +481,12 @@ func TestFastConfirmationWithSafe(t *testing.T) {
 	posted, err := assertionManagerAlice.PostAssertion(ctx)
 	require.NoError(t, err)
 	require.Equal(t, true, posted.IsSome())
-	require.Equal(t, postState, protocol.GoExecutionStateFromSolidity(posted.Unwrap().AfterState))
+	creationInfo, err := aliceChain.ReadAssertionCreationInfo(ctx, posted.Unwrap().Id())
+	require.NoError(t, err)
+	require.Equal(t, postState, protocol.GoExecutionStateFromSolidity(creationInfo.AfterState))
 
 	<-time.After(time.Second)
-	status, err := aliceChain.AssertionStatus(ctx, posted.Unwrap().AssertionHash)
+	status, err := aliceChain.AssertionStatus(ctx, posted.Unwrap().Id())
 	require.NoError(t, err)
 	// Just one fast confirmation is not enough to confirm the assertion.
 	require.Equal(t, protocol.AssertionPending, status)

--- a/assertions/poster_test.go
+++ b/assertions/poster_test.go
@@ -89,5 +89,7 @@ func TestPostAssertion(t *testing.T) {
 	posted, err := assertionManager.PostAssertion(ctx)
 	require.NoError(t, err)
 	require.Equal(t, true, posted.IsSome())
-	require.Equal(t, postState, protocol.GoExecutionStateFromSolidity(posted.Unwrap().AfterState))
+	creationInfo, err := aliceChain.ReadAssertionCreationInfo(ctx, posted.Unwrap().Id())
+	require.NoError(t, err)
+	require.Equal(t, postState, protocol.GoExecutionStateFromSolidity(creationInfo.AfterState))
 }


### PR DESCRIPTION
related to: NIT-3296
Pulled in https://github.com/OffchainLabs/nitro/pull/3183

Refractor PostAssertionBasedOnParent to avoid calling ReadAssertionCreationInfo
This is done so that when `PostAssertionBasedOnParent` is called by `PostAssertion`, it does not error out due to `GetAssertionCreationParentBlock` being called giving error `ASSERTION_NOT_EXIST` on finalized block.

This is safe to do since `PostAssertion` does not need `AssertionCreationParentBlock` anywhere in the flow.