### PR TITLE
Update to modern golangci-lint version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -49,7 +49,7 @@ jobs:
           go-version: 1.23.x
 
       - name: Golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
           version: latest
           args: --timeout=10m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,60 +1,64 @@
-# golangci-lint configuration
-
-run:
-  timeout: 10m
-
-issues:
-  exclude-dirs:
-    - go-ethereum
-    - fastcache
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - staticcheck
-
+version: "2"
 linters:
   enable:
-    - asciicheck  # check for non-ascii characters
-    - errorlint   # enure error wrapping is safely done
-    - gci         # keep imports sorted deterministically
-    - gocritic    # check for certain simplifications
-    - gofmt       # ensure code is formatted
-    - gosec       # check for security concerns
-    - nilerr      # ensure errors aren't mishandled
-    - staticcheck # check for suspicious constructs
-    - unused      # check for unused constructs
-
-linters-settings:
-  errcheck:
-    # report when type assertions aren't checked for errors as in
-    #         a := b.(MyStruct)
-    #
-    check-type-assertions: true
-
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/ethereum/go-ethereum)
-      - prefix(github.com/offchainlabs)
-
-  gocritic:
-    disabled-tags:
-      - experimental
-      - opinionated
-
-    disabled-checks:
-      - ifElseChain
-      - assignOp
-      - unlambda
-      - exitAfterDefer
-
-  gosec:
-    excludes:
-      - G404  # checks that random numbers are securely generated
-
-  govet:
-    enable-all: true
-    disable:
-      - shadow
-      - fieldalignment
+    - asciicheck
+    - errorlint
+    - gocritic
+    - gosec
+    - nilerr
+  settings:
+    errcheck:
+      check-type-assertions: true
+    gocritic:
+      disabled-checks:
+        - ifElseChain
+        - assignOp
+        - unlambda
+        - exitAfterDefer
+      disabled-tags:
+        - experimental
+        - opinionated
+    gosec:
+      excludes:
+        - G404
+    govet:
+      disable:
+        - shadow
+        - fieldalignment
+      enable-all: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - staticcheck
+        path: _test\.go
+    paths:
+      - go-ethereum
+      - fastcache
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/ethereum/go-ethereum)
+        - prefix(github.com/offchainlabs)
+  exclusions:
+    generated: lax
+    paths:
+      - go-ethereum
+      - fastcache
+      - third_party$
+      - builtin$
+      - examples$

--- a/api/server/methods.go
+++ b/api/server/methods.go
@@ -249,9 +249,10 @@ func (s *Server) AllChallengeEdges(w http.ResponseWriter, r *http.Request) {
 	}
 	if val, ok := query["royal"]; ok {
 		v := strings.Join(val, "")
-		if v == "false" {
+		switch v {
+		case "false":
 			opts = append(opts, db.WithRoyal(false))
-		} else if v == "true" {
+		case "true":
 			opts = append(opts, db.WithRoyal(true))
 		}
 	}
@@ -260,9 +261,10 @@ func (s *Server) AllChallengeEdges(w http.ResponseWriter, r *http.Request) {
 	}
 	if val, ok := query["rivaled"]; ok {
 		v := strings.Join(val, "")
-		if v == "false" {
+		switch v {
+		case "false":
 			opts = append(opts, db.WithRival(false))
-		} else if v == "true" {
+		case "true":
 			opts = append(opts, db.WithRival(true))
 		}
 	}
@@ -383,9 +385,10 @@ func (s *Server) AllChallengeEdges(w http.ResponseWriter, r *http.Request) {
 
 func parseEdgeStatus(str string) (protocol.EdgeStatus, error) {
 	s := strings.TrimSpace(strings.ToLower(str))
-	if s == "pending" {
+	switch s {
+	case "pending":
 		return protocol.EdgePending, nil
-	} else if s == "confirmed" {
+	case "confirmed":
 		return protocol.EdgeConfirmed, nil
 	}
 	return protocol.EdgePending, errors.New("unknown edge status, expected pending or confirmed")

--- a/chain-abstraction/sol-implementation/assertion_chain.go
+++ b/chain-abstraction/sol-implementation/assertion_chain.go
@@ -527,7 +527,7 @@ func (a *AssertionChain) NewStake(
 		return nil
 	}
 	_, err = a.transact(ctx, a.backend, func(opts *bind.TransactOpts) (*types.Transaction, error) {
-		return a.userLogic.RollupUserLogicTransactor.NewStake(opts, new(big.Int), a.withdrawalAddress)
+		return a.userLogic.NewStake(opts, new(big.Int), a.withdrawalAddress)
 	})
 	return err
 }
@@ -546,7 +546,7 @@ func (a *AssertionChain) NewStakeOnNewAssertion(
 		assertionInputs rollupgen.AssertionInputs,
 		expectedAssertionHash [32]byte,
 	) (*types.Transaction, error) {
-		return a.userLogic.RollupUserLogicTransactor.NewStakeOnNewAssertion50f32f68(
+		return a.userLogic.NewStakeOnNewAssertion50f32f68(
 			opts,
 			tokenAmount,
 			assertionInputs,
@@ -571,7 +571,7 @@ func (a *AssertionChain) StakeOnNewAssertion(
 	postState *protocol.ExecutionState,
 ) (protocol.Assertion, error) {
 	stakeFn := func(opts *bind.TransactOpts, _ *big.Int, assertionInputs rollupgen.AssertionInputs, assertionHash [32]byte) (*types.Transaction, error) {
-		return a.userLogic.RollupUserLogicTransactor.StakeOnNewAssertion(
+		return a.userLogic.StakeOnNewAssertion(
 			opts,
 			assertionInputs,
 			assertionHash,
@@ -612,7 +612,7 @@ func (a *AssertionChain) createAndStakeOnAssertion(
 	if err != nil {
 		return nil, ErrBatchNotYetFound
 	}
-	computedHash, err := a.userLogic.RollupUserLogicCaller.ComputeAssertionHash(
+	computedHash, err := a.userLogic.ComputeAssertionHash(
 		a.GetCallOptsWithDesiredRpcHeadBlockNumber(&bind.CallOpts{Context: ctx}),
 		parentAssertionCreationInfo.AssertionHash.Hash,
 		postState.AsSolidityStruct(),
@@ -830,7 +830,7 @@ func (a *AssertionChain) ConfirmAssertionByChallengeWinner(
 		return errors.New("assertion prev creation info inbox max count was not a uint64")
 	}
 	receipt, err := a.transact(ctx, a.backend, func(opts *bind.TransactOpts) (*types.Transaction, error) {
-		return a.userLogic.RollupUserLogicTransactor.ConfirmAssertion(
+		return a.userLogic.ConfirmAssertion(
 			opts,
 			b,
 			creationInfo.ParentAssertionHash.Hash,
@@ -864,7 +864,7 @@ func (a *AssertionChain) FastConfirmAssertion(
 		return a.fastConfirmSafe.fastConfirmAssertion(ctx, assertionCreationInfo)
 	}
 	receipt, err := a.transact(ctx, a.backend, func(opts *bind.TransactOpts) (*types.Transaction, error) {
-		return a.userLogic.RollupUserLogicTransactor.FastConfirmAssertion(
+		return a.userLogic.FastConfirmAssertion(
 			opts,
 			assertionCreationInfo.AssertionHash.Hash,
 			assertionCreationInfo.ParentAssertionHash.Hash,

--- a/challenge-manager/chain-watcher/watcher.go
+++ b/challenge-manager/chain-watcher/watcher.go
@@ -522,9 +522,9 @@ func (w *Watcher) AddVerifiedHonestEdge(ctx context.Context, edge protocol.Verif
 	start, startRoot := edge.StartCommitment()
 	end, endRoot := edge.EndCommitment()
 	fields := []any{
-		"edgeId", fmt.Sprintf("%#x", edge.Id().Hash.Bytes()[:4]),
+		"edgeId", fmt.Sprintf("%#x", edge.Id().Bytes()[:4]),
 		"challengeLevel", edge.GetChallengeLevel(),
-		"challengedAssertionHash", fmt.Sprintf("%#x", assertionHash.Hash.Bytes()[:4]),
+		"challengedAssertionHash", fmt.Sprintf("%#x", assertionHash.Bytes()[:4]),
 		"startHeight", start,
 		"endHeight", end,
 		"startCommit", fmt.Sprintf("%#x", startRoot[:4]),
@@ -628,9 +628,9 @@ func (w *Watcher) AddEdge(ctx context.Context, edge protocol.SpecEdge) (bool, er
 		}
 	}
 	fields := []any{
-		"edgeId", fmt.Sprintf("%#x", edge.Id().Hash.Bytes()[:4]),
+		"edgeId", fmt.Sprintf("%#x", edge.Id().Bytes()[:4]),
 		"challengeLevel", edge.GetChallengeLevel(),
-		"challengedAssertionHash", fmt.Sprintf("%#x", challengeParentAssertionHash.Hash.Bytes()[:4]),
+		"challengedAssertionHash", fmt.Sprintf("%#x", challengeParentAssertionHash.Bytes()[:4]),
 		"startHeight", start,
 		"endHeight", end,
 		"startCommit", fmt.Sprintf("%#x", startRoot[:4]),
@@ -857,7 +857,7 @@ func (w *Watcher) confirmAssertionByChallengeWinner(ctx context.Context, edge pr
 		return
 	}
 	challengeGracePeriodBlocks, err := retry.UntilSucceeds(ctx, func() (uint64, error) {
-		return w.chain.RollupUserLogic().RollupUserLogicCaller.ChallengeGracePeriodBlocks(w.chain.GetCallOptsWithDesiredRpcHeadBlockNumber(&bind.CallOpts{Context: ctx}))
+		return w.chain.RollupUserLogic().ChallengeGracePeriodBlocks(w.chain.GetCallOptsWithDesiredRpcHeadBlockNumber(&bind.CallOpts{Context: ctx}))
 	})
 	if err != nil {
 		log.Error("Could not get challenge grace period blocks", "err", err)

--- a/challenge-manager/edge-tracker/tracker.go
+++ b/challenge-manager/edge-tracker/tracker.go
@@ -421,7 +421,7 @@ func (et *Tracker) uniqueTrackerLogFields() []any {
 	endHeight, endCommit := et.edge.EndCommitment()
 	chalLevel := et.edge.GetChallengeLevel()
 	return []any{
-		"id", fmt.Sprintf("%#x", et.edge.Id().Hash.Bytes()[:4]),
+		"id", fmt.Sprintf("%#x", et.edge.Id().Bytes()[:4]),
 		"fromBatch", et.associatedAssertionMetadata.FromState.Batch,
 		"fromPosInBatch", et.associatedAssertionMetadata.FromState.PosInBatch,
 		"batchLimit", et.associatedAssertionMetadata.BatchLimit,

--- a/logs/ephemeral/log.go
+++ b/logs/ephemeral/log.go
@@ -49,7 +49,7 @@ func (h *EphemeralErrorHandler) LogLevel(err error, currentLogLevel func(msg str
 		return currentLogLevel
 	}
 
-	if *h.FirstOccurrence == (time.Time{}) {
+	if h.FirstOccurrence.Equal((time.Time{})) {
 		*h.FirstOccurrence = time.Now()
 	}
 

--- a/testing/endtoend/backend/anvil_local.go
+++ b/testing/endtoend/backend/anvil_local.go
@@ -265,7 +265,7 @@ func (a *AnvilLocal) DeployRollup(ctx context.Context, opts ...challenge_testing
 		return nil, errors.New("could not set big int")
 	}
 	for _, acc := range a.accounts[1:] {
-		transferTx, err := tokenBindings.TestWETH9Transactor.Transfer(a.accounts[0], acc.From, seed)
+		transferTx, err := tokenBindings.Transfer(a.accounts[0], acc.From, seed)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not approve account")
 		}
@@ -279,7 +279,7 @@ func (a *AnvilLocal) DeployRollup(ctx context.Context, opts ...challenge_testing
 		if receipt.Status != types.ReceiptStatusSuccessful {
 			return nil, errors.New("receipt not successful")
 		}
-		approveTx, err := tokenBindings.TestWETH9Transactor.Approve(acc, result.Rollup, value)
+		approveTx, err := tokenBindings.Approve(acc, result.Rollup, value)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not approve account")
 		}
@@ -293,7 +293,7 @@ func (a *AnvilLocal) DeployRollup(ctx context.Context, opts ...challenge_testing
 		if receipt.Status != types.ReceiptStatusSuccessful {
 			return nil, errors.New("receipt not successful")
 		}
-		approveTx, err = tokenBindings.TestWETH9Transactor.Approve(acc, chalManagerAddr, value)
+		approveTx, err = tokenBindings.Approve(acc, chalManagerAddr, value)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not approve account")
 		}

--- a/testing/setup/rollup_stack.go
+++ b/testing/setup/rollup_stack.go
@@ -413,7 +413,7 @@ func ChainsWithEdgeChallengeManager(opts ...Opt) (*ChainSetup, error) {
 			return nil, err
 		}
 		var challengeManagerAddr common.Address
-		challengeManagerAddr, err = assertionChainBinding.RollupUserLogicCaller.ChallengeManager(
+		challengeManagerAddr, err = assertionChainBinding.ChallengeManager(
 			&bind.CallOpts{Context: ctx},
 		)
 		if err != nil {
@@ -447,7 +447,7 @@ func ChainsWithEdgeChallengeManager(opts ...Opt) (*ChainSetup, error) {
 	}
 	for i := 0; i < len(accs); i++ {
 		acc := accs[i]
-		transferTx, err := tokenBindings.TestWETH9Transactor.Transfer(accs[0].TxOpts, acc.TxOpts.From, seed)
+		transferTx, err := tokenBindings.Transfer(accs[0].TxOpts, acc.TxOpts.From, seed)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not approve account")
 		}
@@ -461,7 +461,7 @@ func ChainsWithEdgeChallengeManager(opts ...Opt) (*ChainSetup, error) {
 		if receipt.Status != types.ReceiptStatusSuccessful {
 			return nil, errors.New("receipt not successful")
 		}
-		approveTx, err := tokenBindings.TestWETH9Transactor.Approve(acc.TxOpts, addresses.Rollup, value)
+		approveTx, err := tokenBindings.Approve(acc.TxOpts, addresses.Rollup, value)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not approve account")
 		}
@@ -475,7 +475,7 @@ func ChainsWithEdgeChallengeManager(opts ...Opt) (*ChainSetup, error) {
 		if receipt.Status != types.ReceiptStatusSuccessful {
 			return nil, errors.New("receipt not successful")
 		}
-		approveTx, err = tokenBindings.TestWETH9Transactor.Approve(acc.TxOpts, chalManagerAddr, value)
+		approveTx, err = tokenBindings.Approve(acc.TxOpts, chalManagerAddr, value)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not approve account")
 		}

--- a/util/backend.go
+++ b/util/backend.go
@@ -28,7 +28,7 @@ func NewBackendWrapper(client *ethclient.Client, desiredBlockNum rpc.BlockNumber
 }
 
 func (b BackendWrapper) HeaderU64(ctx context.Context) (uint64, error) {
-	header, err := b.ethClient.HeaderByNumber(ctx, big.NewInt(int64(b.desiredBlockNum)))
+	header, err := b.HeaderByNumber(ctx, big.NewInt(int64(b.desiredBlockNum)))
 	if err != nil {
 		return 0, err
 	}

--- a/util/stopwaiter/stopwaiter.go
+++ b/util/stopwaiter/stopwaiter.go
@@ -230,19 +230,19 @@ func (s *StopWaiter) StopAndWait() {
 
 // If stop was already called, thread might silently not be launched
 func (s *StopWaiter) LaunchThread(foo func(context.Context)) {
-	if err := s.StopWaiterSafe.LaunchThreadSafe(foo); err != nil {
+	if err := s.LaunchThreadSafe(foo); err != nil {
 		panic(err)
 	}
 }
 
 func (s *StopWaiter) CallIteratively(foo func(context.Context) time.Duration) {
-	if err := s.StopWaiterSafe.CallIterativelySafe(foo); err != nil {
+	if err := s.CallIterativelySafe(foo); err != nil {
 		panic(err)
 	}
 }
 
 func (s *StopWaiter) GetContext() context.Context {
-	ctx, err := s.StopWaiterSafe.GetContextSafe()
+	ctx, err := s.GetContextSafe()
 	if err != nil {
 		panic(err)
 	}
@@ -250,7 +250,7 @@ func (s *StopWaiter) GetContext() context.Context {
 }
 
 func (s *StopWaiter) GetParentContext() context.Context {
-	ctx, err := s.StopWaiterSafe.GetParentContextSafe()
+	ctx, err := s.GetParentContextSafe()
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This updates the configuration file to work with versions of golangci-lint greater than 2.0 and also upgrades the CI action to version 8 (from version 3).