### PR TITLE
Print transaction info in hex format for fast confirm logs

### DIFF
--- a/chain-abstraction/sol-implementation/fast_confirm.go
+++ b/chain-abstraction/sol-implementation/fast_confirm.go
@@ -212,6 +212,6 @@ func (f *FastConfirmSafe) checkApprovedHashAndExecTransaction(
 		}
 		return true, nil
 	}
-	log.Info("Not enough Safe tx approvals yet to fast confirm", "safeHash", safeTxHash)
+	log.Info("Not enough Safe tx approvals yet to fast confirm", "safeHash", common.BytesToHash(safeTxHash[:]).Hex())
 	return false, nil
 }


### PR DESCRIPTION
Related to NIT-3475
Print transaction info in hex format for fast confirm logs